### PR TITLE
Fix Struct de/serialization (or make it more consistent)

### DIFF
--- a/lib/protobuf_util.ex
+++ b/lib/protobuf_util.ex
@@ -9,10 +9,9 @@ defmodule Relay.ProtobufUtil do
   defp oneof_actual_vals(message_props, struct) do
     # Copy/pasta-ed from:
     # https://github.com/tony612/protobuf-elixir/blob/a4389fe18edc70430563d8591aa05bd3dba60adc/lib/protobuf/encoder.ex#L153-L160
-    # TODO: Make this more readable
-    Enum.reduce(message_props.oneof, %{}, fn {field, _}, acc ->
-      case Map.get(struct, field) do
-        {f, val} -> Map.put(acc, f, val)
+    Enum.reduce(message_props.oneof, %{}, fn {oneof_field, _}, acc ->
+      case Map.get(struct, oneof_field) do
+        {field, value} -> Map.put(acc, field, value)
         nil -> acc
       end
     end)

--- a/test/protobuf_util_test.exs
+++ b/test/protobuf_util_test.exs
@@ -2,29 +2,7 @@ defmodule Relay.ProtobufUtilTest do
   use ExUnit.Case, async: true
 
   alias Relay.ProtobufUtil
-  alias Google.Protobuf.{Any, ListValue, NullValue, Struct, Value}
-
-  test "null type packed" do
-    defmodule NullType do
-      use Protobuf, syntax: :proto3
-
-      @type t :: %__MODULE__{
-        foo: Struct.t
-      }
-      defstruct [:foo]
-
-      field :foo, 1, type: Struct
-    end
-
-    proto = NullType.new() # Don't provide foo
-    struct = ProtobufUtil.mkstruct(proto)
-
-    assert struct == %Struct{
-      fields: %{
-        "foo" => %Value{kind: {:null_value, NullValue.value(:NULL_VALUE)}},
-      }
-    }
-  end
+  alias Google.Protobuf.{Any, ListValue, Struct, Value}
 
   test "basic types packed" do
     defmodule BasicTypes do
@@ -162,7 +140,6 @@ defmodule Relay.ProtobufUtilTest do
 
     assert struct == %Struct{
       fields: %{
-        "foo" => %Value{kind: {:null_value, NullValue.value(:NULL_VALUE)}},
         "bar" => %Value{kind: {:bool_value, true}},
         "baz" => %Value{kind: {:string_value, "def"}},
       }
@@ -205,6 +182,28 @@ defmodule Relay.ProtobufUtilTest do
     proto = SerializedType.new(foo: "baz")
     struct = ProtobufUtil.mkstruct(proto)
 
+    serialized = Struct.encode(struct)
+    assert Struct.decode(serialized) == struct
+  end
+
+  test "oneof structs serialize and deserialize to the same thing" do
+    defmodule OneofSerializedType do
+      use Protobuf, syntax: :proto3
+
+      @type t :: %__MODULE__{
+        foobar: {atom, any},
+        baz: String.t
+      }
+      defstruct [:foobar, :baz]
+
+      oneof :foobar, 0
+      field :foo, 1, type: :uint32, oneof: 0
+      field :bar, 2, type: :bool, oneof: 0
+      field :baz, 3, type: :string
+    end
+
+    proto = OneofSerializedType.new(foobar: {:bar, true}, baz: "def")
+    struct = ProtobufUtil.mkstruct(proto)
     serialized = Struct.encode(struct)
     assert Struct.decode(serialized) == struct
   end

--- a/test/protobuf_util_test.exs
+++ b/test/protobuf_util_test.exs
@@ -188,6 +188,27 @@ defmodule Relay.ProtobufUtilTest do
     end
   end
 
+  test "structs serialize and deserialize to the same thing" do
+    defmodule SerializedType do
+      use Protobuf, syntax: :proto3
+
+      @type t :: %__MODULE__{
+        foo: String.t,
+        bar: String.t
+      }
+      defstruct [:foo, :bar]
+
+      field :foo, 1, type: :string
+      field :bar, 2, type: :string
+    end
+
+    proto = SerializedType.new(foo: "baz")
+    struct = ProtobufUtil.mkstruct(proto)
+
+    serialized = Struct.encode(struct)
+    assert Struct.decode(serialized) == struct
+  end
+
   test "Any encodes a type" do
     proto = Value.new(kind: {:string_value, "abcdef"})
     any = ProtobufUtil.mkany("example.com/mytype", proto)


### PR DESCRIPTION
Skip adding default or null field values to the `Struct`s. I _think_ this makes sense because Envoy converts the Structs into an actual protobuf type on the other side and that will include default/null values whether we specify them or not.