### PR TITLE
 Add Relay.Marathon.State to store all apps & corresponding tasks

### DIFF
--- a/lib/relay/marathon.ex
+++ b/lib/relay/marathon.ex
@@ -93,14 +93,15 @@ defmodule Relay.Marathon do
     unchanged.
     """
     def delete_app(%State{apps: apps, tasks: tasks, app_tasks: app_tasks} = state, %App{id: id}) do
-      {app, new_apps} = Map.pop(apps, id)
+      case Map.pop(apps, id) do
+        {%App{}, new_apps} ->
+          {tasks_for_app, new_app_tasks} = Map.pop(app_tasks, id)
+          new_tasks = Map.drop(tasks, tasks_for_app)
 
-      if app do
-        {tasks_for_app, new_app_tasks} = Map.pop(app_tasks, id)
+          %{state | apps: new_apps, tasks: new_tasks, app_tasks: new_app_tasks}
 
-        %{state | apps: new_apps, tasks: Map.drop(tasks, tasks_for_app), app_tasks: new_app_tasks}
-      else
-        state
+        {nil, _} ->
+          state
       end
     end
 

--- a/lib/relay/marathon.ex
+++ b/lib/relay/marathon.ex
@@ -52,4 +52,115 @@ defmodule Relay.Marathon do
     def endpoint(%Task{address: address, ports: ports}, port_index),
       do: {address, Enum.at(ports, port_index)}
   end
+
+  defmodule State do
+    defstruct apps: %{}, tasks: %{}, app_tasks: %{}
+
+    @doc """
+    Add an app to `state`. The app is only added if its version is newer than
+    the existing app.
+
+    Returns a tuple where the first element is the version of the app already in
+    the state (or `nil` if there was no app with the ID) and the second element
+    is the new state.
+    """
+    def put_app(%State{apps: apps} = state, %App{id: id, version: version} = app) do
+      case Map.get(apps, id) do
+        # App is newer than existing app, update the app
+        %App{version: existing_version} when version > existing_version ->
+          {existing_version, update_app!(state, app)}
+
+        # App is the same or older than existing app, do nothing
+        %App{version: existing_version} ->
+          {existing_version, state}
+
+        # No existing app with this ID, add this one
+        nil ->
+          {nil, add_app(state, app)}
+      end
+    end
+
+    defp add_app(%State{apps: apps, app_tasks: app_tasks} = state, %App{id: id} = app),
+      do: %{state | apps: Map.put(apps, id, app), app_tasks: Map.put(app_tasks, id, MapSet.new())}
+
+    defp update_app!(%State{apps: apps} = state, %App{id: id} = app),
+      do: %{state | apps: Map.replace!(apps, id, app)}
+
+    @doc """
+    Delete an app from the state. All tasks for the app will also be removed.
+
+    Returns the new state. If the app is not in `state`, returns `state`
+    unchanged.
+    """
+    def delete_app(%State{apps: apps, tasks: tasks, app_tasks: app_tasks} = state, %App{id: id}) do
+      {app, new_apps} = Map.pop(apps, id)
+
+      if app do
+        {tasks_for_app, new_app_tasks} = Map.pop(app_tasks, id)
+
+        %{state | apps: new_apps, tasks: Map.drop(tasks, tasks_for_app), app_tasks: new_app_tasks}
+      else
+        state
+      end
+    end
+
+    @doc """
+    Add a task to `state`. The task is only added if its version is newer than
+    the existing task.
+
+    Returns a tuple where the first element is the version of the task already
+    in the state (or `nil` if there was no task with the ID) and the second
+    element is the new state.
+
+    Raises a `KeyError` if the app that the task belongs to is not in `state`.
+    """
+    def put_task!(%State{tasks: tasks} = state, %Task{id: id, version: version} = task) do
+      case Map.get(tasks, id) do
+        # Task is newer than existing task, update the task
+        %Task{version: existing_version} when version > existing_version ->
+          {existing_version, update_task!(state, task)}
+
+        # Task is the same or older than existing task, do nothing
+        %Task{version: existing_version} ->
+          {existing_version, state}
+
+        # No existing task with this ID, add this one
+        nil ->
+          {nil, add_task!(state, task)}
+      end
+    end
+
+    defp add_task!(
+           %State{tasks: tasks, app_tasks: app_tasks} = state,
+           %Task{id: id, app_id: app_id} = task
+         ) do
+      %{
+        state
+        | tasks: Map.put(tasks, id, task),
+          app_tasks: Map.update!(app_tasks, app_id, fn tasks -> MapSet.put(tasks, id) end)
+      }
+    end
+
+    defp update_task!(%State{tasks: tasks} = state, %Task{id: id} = task),
+      do: %{state | tasks: Map.replace!(tasks, id, task)}
+
+    @doc """
+    Delete a task from `state`.
+
+    Returns the new state. If the task is not in `state`, returns `state`
+    unchanged.
+
+    Raises a `KeyError` if the app that the task belongs to is not in `state`.
+    """
+    def delete_task!(%State{tasks: tasks, app_tasks: app_tasks} = state, %Task{
+          id: id,
+          app_id: app_id
+        }) do
+      %{
+        state
+        | tasks: Map.delete(tasks, id),
+          app_tasks: Map.update!(app_tasks, app_id, fn tasks -> MapSet.delete(tasks, id) end)
+      }
+    end
+  end
 end

--- a/test/relay/marathon_test.exs
+++ b/test/relay/marathon_test.exs
@@ -76,41 +76,6 @@ defmodule Relay.MarathonTest do
     "deployments" => []
   }
 
-  test "app from definition" do
-    assert App.from_definition(@test_app) == %App{
-      id: "/mc2",
-      labels: %{
-        "HAPROXY_0_REDIRECT_TO_HTTPS" => "true",
-        "HAPROXY_0_VHOST" => "mc2.example.org",
-        "HAPROXY_GROUP" => "external",
-        "MARATHON_ACME_0_DOMAIN" => "mc2.example.org"
-      },
-      networking_mode: :"container/bridge",
-      ports_list: [80],
-      version: "2017-11-08T15:06:31.066Z"
-    }
-  end
-
-  test "app port indices in group" do
-    app = App.from_definition(@test_app)
-
-    assert App.port_indices_in_group(app, "internal") == []
-    assert App.port_indices_in_group(app, "external") == [0]
-  end
-
-  test "app label getters" do
-    app = App.from_definition(@test_app)
-
-    assert App.marathon_lb_vhost(app, 0) == ["mc2.example.org"]
-    assert App.marathon_lb_vhost(app, 1) == []
-
-    assert App.marathon_lb_redirect_to_https?(app, 0)
-    assert not App.marathon_lb_redirect_to_https?(app, 1)
-
-    assert App.marathon_acme_domain(app, 0) == ["mc2.example.org"]
-    assert App.marathon_acme_domain(app, 1) == []
-  end
-
   @test_task %{
     "ipAddresses" => [
       %{
@@ -131,36 +96,75 @@ defmodule Relay.MarathonTest do
     "host" => "10.70.4.100"
   }
 
-  test "task from definition" do
-    app = App.from_definition(@test_app)
+  describe "Marathon.App" do
+    test "app from definition" do
+      assert App.from_definition(@test_app) == %App{
+        id: "/mc2",
+        labels: %{
+          "HAPROXY_0_REDIRECT_TO_HTTPS" => "true",
+          "HAPROXY_0_VHOST" => "mc2.example.org",
+          "HAPROXY_GROUP" => "external",
+          "MARATHON_ACME_0_DOMAIN" => "mc2.example.org"
+        },
+        networking_mode: :"container/bridge",
+        ports_list: [80],
+        version: "2017-11-08T15:06:31.066Z"
+      }
+    end
 
-    assert Task.from_definition(app, @test_task) == %Task{
-      address: "10.70.4.100",
-      app_id: "/mc2",
-      id: "mc2.be753491-1325-11e8-b5d6-4686525b33db",
-      ports: [15979],
-      version: "2017-11-09T08:43:59.890Z"
-    }
+    test "app port indices in group" do
+      app = App.from_definition(@test_app)
+
+      assert App.port_indices_in_group(app, "internal") == []
+      assert App.port_indices_in_group(app, "external") == [0]
+    end
+
+    test "app label getters" do
+      app = App.from_definition(@test_app)
+
+      assert App.marathon_lb_vhost(app, 0) == ["mc2.example.org"]
+      assert App.marathon_lb_vhost(app, 1) == []
+
+      assert App.marathon_lb_redirect_to_https?(app, 0)
+      assert not App.marathon_lb_redirect_to_https?(app, 1)
+
+      assert App.marathon_acme_domain(app, 0) == ["mc2.example.org"]
+      assert App.marathon_acme_domain(app, 1) == []
+    end
   end
 
-  test "task from definition container networking" do
-    app =
-      @test_app
-      |> Map.put("networks", [%{"mode" => "container", "name" => "dcos"}])
-      |> App.from_definition()
+  describe "Marathon.Task" do
+    test "task from definition" do
+      app = App.from_definition(@test_app)
 
-    assert Task.from_definition(app, @test_task) == %Task{
-      address: "172.17.0.9",
-      app_id: "/mc2",
-      id: "mc2.be753491-1325-11e8-b5d6-4686525b33db",
-      ports: [80],
-      version: "2017-11-09T08:43:59.890Z"
-    }
-  end
+      assert Task.from_definition(app, @test_task) == %Task{
+        address: "10.70.4.100",
+        app_id: "/mc2",
+        id: "mc2.be753491-1325-11e8-b5d6-4686525b33db",
+        ports: [15979],
+        version: "2017-11-09T08:43:59.890Z"
+      }
+    end
 
-  test "task port" do
-    task = Task.from_definition(App.from_definition(@test_app), @test_task)
+    test "task from definition container networking" do
+      app =
+        @test_app
+        |> Map.put("networks", [%{"mode" => "container", "name" => "dcos"}])
+        |> App.from_definition()
 
-    assert Task.endpoint(task, 0) == {"10.70.4.100", 15979}
+      assert Task.from_definition(app, @test_task) == %Task{
+        address: "172.17.0.9",
+        app_id: "/mc2",
+        id: "mc2.be753491-1325-11e8-b5d6-4686525b33db",
+        ports: [80],
+        version: "2017-11-09T08:43:59.890Z"
+      }
+    end
+
+    test "task port" do
+      task = Task.from_definition(App.from_definition(@test_app), @test_task)
+
+      assert Task.endpoint(task, 0) == {"10.70.4.100", 15979}
+    end
   end
 end


### PR DESCRIPTION
The idea here is that given a list of all apps and tasks, we can produce the corresponding Envoy constructs. When we add something to this `State` thing and we get a version of a task or app back that is older than the one we just added, then we sync the new state with Envoy.