### PR TITLE
Log wrapper

### DIFF
--- a/lib/log_wrapper.ex
+++ b/lib/log_wrapper.ex
@@ -1,0 +1,29 @@
+defmodule LogWrapper do
+
+  @moduledoc """
+  LogWrapper is a wrapper around the `Logger` module that exists solely to
+  throw away return values. This gets rid of dialyzer `unmatched_returns`
+  warning noise without sprinkling `_ = Logger.whatever` all over our code or
+  manually maintaining a bunch of per-line ignore entries.
+  """
+
+  defmacro __using__(alias_opts) do
+    quote do
+      require LogWrapper
+      alias LogWrapper, unquote(alias_opts)
+    end
+  end
+
+  @doc """
+  Logs a debug message.
+
+  Always returns `:ok`, blissfully ignoring any logger errors.
+  """
+  defmacro debug(chardata_or_fun, metadata \\ []) do
+    quote do
+      require Logger
+      _ = Logger.debug(unquote(chardata_or_fun), unquote(metadata))
+      :ok
+    end
+  end
+end

--- a/lib/marathon_client/sse_client.ex
+++ b/lib/marathon_client/sse_client.ex
@@ -4,10 +4,7 @@ defmodule MarathonClient.SSEClient do
   data chunks to the SSE parser.
   """
 
-  # The logging "functions" are actually macros, so we need to `require Logger`
-  # in order to access them. We match the return value to `_` to keep dialyzer
-  # happy without allowing a failed log message to break stuff.
-  require Logger
+  use LogWrapper, as: Log
 
   use GenServer
 
@@ -36,7 +33,7 @@ defmodule MarathonClient.SSEClient do
       %HTTPoison.AsyncStatus{code: 200} ->
         {:ok, {r, ssep}}
       msg ->
-        _ = Logger.debug("Failed to connect to stream: #{inspect msg}")
+        Log.debug("Failed to connect to stream: #{inspect msg}")
         {:stop, "Error connecting to event stream: #{inspect msg}"}
     end
   end
@@ -60,7 +57,7 @@ defmodule MarathonClient.SSEClient do
   end
 
   def handle_info(msg, state) do
-    _ = Logger.debug("Unexpected message: #{inspect msg}") # noqa
+    Log.debug("Unexpected message: #{inspect msg}") # noqa
     {:noreply, state}
   end
 end


### PR DESCRIPTION
Littering our code with `_ = Logger.whatever` to keep dialyzer happy is annoying.