### PR TITLE
Store port indices in the marathon-lb group in App structs

### DIFF
--- a/lib/relay/demo.ex
+++ b/lib/relay/demo.ex
@@ -142,7 +142,7 @@ defmodule Relay.Demo do
     [
       RouteConfiguration.new(
         name: "http",
-        virtual_hosts: [Adapter.app_port_virtual_host(:http, @demo_app, 0)]
+        virtual_hosts: Adapter.app_virtual_hosts(:http, @demo_app)
       )
     ]
   end

--- a/lib/relay/demo.ex
+++ b/lib/relay/demo.ex
@@ -148,6 +148,6 @@ defmodule Relay.Demo do
   end
 
   def endpoints do
-    [Adapter.app_port_cluster_load_assignment(@demo_app, [@demo_task], 0)]
+    Adapter.app_cluster_load_assignments(@demo_app, [@demo_task])
   end
 end

--- a/lib/relay/demo.ex
+++ b/lib/relay/demo.ex
@@ -12,6 +12,7 @@ defmodule Relay.Demo do
     },
     networking_mode: :"container/bridge",
     ports_list: [80],
+    port_indices_in_group: [0],
     version: "2017-11-08T15:06:31.066Z"
   }
 
@@ -86,7 +87,7 @@ defmodule Relay.Demo do
   end
 
   def clusters do
-    [Adapter.app_port_cluster(@demo_app, 0, own_api_config_source())]
+    Adapter.app_clusters(@demo_app, own_api_config_source())
   end
 
   defp router_filter do

--- a/lib/relay/marathon/adapter.ex
+++ b/lib/relay/marathon/adapter.ex
@@ -15,16 +15,26 @@ defmodule Relay.Marathon.Adapter do
   @default_locality Locality.new(region: "default")
 
   @doc """
-  Create a Cluster for the given app and port index. The Cluster will have the
-  minimum amount of options set but will be a Cluster with EDS endpoint
-  discovery. Additional options can be specified using `options`.
+  Create Clusters for the given app. The Clusters will have the minimum amount
+  of options set but will be Clusters with EDS endpoint discovery. Additional
+  options can be specified using `options`.
   """
+  @spec app_clusters(App.t, ConfigSource.t, keyword) :: [Cluster.t]
+  def app_clusters(
+        %App{port_indices_in_group: port_indices_in_group} = app,
+        %ConfigSource{} = eds_config_source,
+        options \\ []
+      ) do
+    port_indices_in_group
+    |> Enum.map(&app_port_cluster(app, &1, eds_config_source, options))
+  end
+
   @spec app_port_cluster(App.t, non_neg_integer, ConfigSource.t, keyword) :: Cluster.t
-  def app_port_cluster(
+  defp app_port_cluster(
         %App{id: app_id},
         port_index,
         %ConfigSource{} = eds_config_source,
-        options \\ []
+        options
       ) do
     service_name = "#{app_id}_#{port_index}"
     {max_size, options} = max_obj_name_length(options)

--- a/lib/relay/marathon/adapter.ex
+++ b/lib/relay/marathon/adapter.ex
@@ -80,8 +80,8 @@ defmodule Relay.Marathon.Adapter do
   end
 
   @doc """
-  Create a ClusterLoadAssignment for the given app, tasks, and port index. The
-  ClusterLoadAssignment will have the minimum amount of options set.
+  Create ClusterLoadAssignments for the given app and tasks. The
+  ClusterLoadAssignments will have the minimum amount of options set.
 
   Additional options can be specified using `options` and options for nested
   types are nested within that:
@@ -89,9 +89,19 @@ defmodule Relay.Marathon.Adapter do
   - LocalityLbEndpoints: `options.locality_lb_endpoints_opts`
   - LbEndpoint: `options.locality_lb_endpoints_opts.lb_endpoint_opts`
   """
+  @spec app_cluster_load_assignments(App.t, [Task.t], keyword) :: [ClusterLoadAssignment.t]
+  def app_cluster_load_assignments(
+        %App{port_indices_in_group: port_indices_in_group} = app,
+        tasks,
+        options \\ []
+      ) do
+    port_indices_in_group
+    |> Enum.map(&app_port_cluster_load_assignment(app, tasks, &1, options))
+  end
+
   @spec app_port_cluster_load_assignment(App.t, [Task.t], non_neg_integer, keyword) ::
           ClusterLoadAssignment.t
-  def app_port_cluster_load_assignment(%App{id: app_id}, tasks, port_index, options \\ []) do
+  defp app_port_cluster_load_assignment(%App{id: app_id}, tasks, port_index, options) do
     {llbe_opts, options} = Keyword.pop(options, :locality_lb_endpoints_opts, [])
 
     ClusterLoadAssignment.new(

--- a/lib/relay/marathon/adapter.ex
+++ b/lib/relay/marathon/adapter.ex
@@ -154,7 +154,7 @@ defmodule Relay.Marathon.Adapter do
   - RouteAction: `options.route_opts.action_opts`
   - RouteMatch: `options.route_opts.match_opts`
   """
-  @spec app_virtual_hosts(atom, App.t, keyword) :: VirtualHost.t
+  @spec app_virtual_hosts(atom, App.t, keyword) :: [VirtualHost.t]
   def app_virtual_hosts(
         listener,
         %App{port_indices_in_group: port_indices_in_group} = app,

--- a/lib/relay/marathon/app.ex
+++ b/lib/relay/marathon/app.ex
@@ -1,6 +1,7 @@
 defmodule Relay.Marathon.App do
   alias Relay.Marathon.{Labels, Networking}
 
+  @enforce_keys [:id, :networking_mode, :ports_list, :port_indices_in_group, :labels, :version]
   defstruct [:id, :networking_mode, :ports_list, :port_indices_in_group, :labels, :version]
 
   @type t :: %__MODULE__{

--- a/lib/relay/marathon/app.ex
+++ b/lib/relay/marathon/app.ex
@@ -1,29 +1,40 @@
 defmodule Relay.Marathon.App do
   alias Relay.Marathon.{Labels, Networking}
 
-  defstruct [:id, :networking_mode, :ports_list, :labels, :version]
+  defstruct [:id, :networking_mode, :ports_list, :port_indices_in_group, :labels, :version]
   @type t :: %__MODULE__{
     id: String.t,
     networking_mode: Networking.networking_mode,
     ports_list: [Networking.port_number],
+    port_indices_in_group: [non_neg_integer],
     labels: Labels.labels,
     version: String.t
   }
 
-  @spec from_definition(map) :: t
-  def from_definition(%{"id" => id, "labels" => labels} = app) do
+  @spec from_definition(map, String.t) :: t
+  def from_definition(%{"id" => id, "labels" => labels} = app, group) do
+    ports_list = Networking.ports_list(app)
     %__MODULE__{
       id: id,
       networking_mode: Networking.networking_mode(app),
-      ports_list: Networking.ports_list(app),
+      ports_list: ports_list,
+      port_indices_in_group: port_indices_in_group(ports_list, labels, group),
       labels: labels,
       version: version(app)
     }
   end
 
-  @spec from_event(map) :: t
-  def from_event(%{"eventType" => "api_post_event", "appDefinition" => definition} = _event),
-    do: from_definition(definition)
+  @spec from_event(map, String.t) :: t
+  def from_event(%{"eventType" => "api_post_event", "appDefinition" => definition} = _event, group),
+    do: from_definition(definition, group)
+
+  defp port_indices_in_group([], _labels, _group), do: []
+
+  @spec port_indices_in_group([Networking.port_number], %{String.t => String.t}, String.t) :: [non_neg_integer]
+  defp port_indices_in_group(ports_list, labels, group) do
+    0..(length(ports_list) - 1)
+    |> Enum.filter(fn port_index -> Labels.marathon_lb_group(labels, port_index) == group end)
+  end
 
   @spec version(map) :: String.t()
   defp version(app) do
@@ -33,14 +44,6 @@ defmodule Relay.Marathon.App do
       # ...but if this is an app that hasn't been changed yet then use `version`
       %{"version" => version} -> version
     end
-  end
-
-  def port_indices_in_group(%__MODULE__{ports_list: []}, _group), do: []
-
-  @spec port_indices_in_group(t, String.t) :: [non_neg_integer]
-  def port_indices_in_group(%__MODULE__{ports_list: ports_list, labels: labels}, group) do
-    0..(length(ports_list) - 1)
-    |> Enum.filter(fn port_index -> Labels.marathon_lb_group(labels, port_index) == group end)
   end
 
   @spec marathon_lb_vhost(t, non_neg_integer) :: [String.t]

--- a/lib/relay/marathon/app.ex
+++ b/lib/relay/marathon/app.ex
@@ -2,18 +2,20 @@ defmodule Relay.Marathon.App do
   alias Relay.Marathon.{Labels, Networking}
 
   defstruct [:id, :networking_mode, :ports_list, :port_indices_in_group, :labels, :version]
-  @type t :: %__MODULE__{
-    id: String.t,
-    networking_mode: Networking.networking_mode,
-    ports_list: [Networking.port_number],
-    port_indices_in_group: [non_neg_integer],
-    labels: Labels.labels,
-    version: String.t
-  }
 
-  @spec from_definition(map, String.t) :: t
+  @type t :: %__MODULE__{
+          id: String.t(),
+          networking_mode: Networking.networking_mode(),
+          ports_list: [Networking.port_number()],
+          port_indices_in_group: [non_neg_integer],
+          labels: Labels.labels(),
+          version: String.t()
+        }
+
+  @spec from_definition(map, String.t()) :: t
   def from_definition(%{"id" => id, "labels" => labels} = app, group) do
     ports_list = Networking.ports_list(app)
+
     %__MODULE__{
       id: id,
       networking_mode: Networking.networking_mode(app),
@@ -24,13 +26,17 @@ defmodule Relay.Marathon.App do
     }
   end
 
-  @spec from_event(map, String.t) :: t
-  def from_event(%{"eventType" => "api_post_event", "appDefinition" => definition} = _event, group),
-    do: from_definition(definition, group)
+  @spec from_event(map, String.t()) :: t
+  def from_event(
+        %{"eventType" => "api_post_event", "appDefinition" => definition} = _event,
+        group
+      ),
+      do: from_definition(definition, group)
 
   defp port_indices_in_group([], _labels, _group), do: []
 
-  @spec port_indices_in_group([Networking.port_number], %{String.t => String.t}, String.t) :: [non_neg_integer]
+  @spec port_indices_in_group([Networking.port_number()], %{String.t() => String.t()}, String.t()) ::
+          [non_neg_integer]
   defp port_indices_in_group(ports_list, labels, group) do
     0..(length(ports_list) - 1)
     |> Enum.filter(fn port_index -> Labels.marathon_lb_group(labels, port_index) == group end)
@@ -40,13 +46,16 @@ defmodule Relay.Marathon.App do
   defp version(app) do
     case app do
       # In most cases the `lastConfigChangeAt` value should be available...
-      %{"versionInfo" => %{"lastConfigChangeAt" => version}} -> version
+      %{"versionInfo" => %{"lastConfigChangeAt" => version}} ->
+        version
+
       # ...but if this is an app that hasn't been changed yet then use `version`
-      %{"version" => version} -> version
+      %{"version" => version} ->
+        version
     end
   end
 
-  @spec marathon_lb_vhost(t, non_neg_integer) :: [String.t]
+  @spec marathon_lb_vhost(t, non_neg_integer) :: [String.t()]
   def marathon_lb_vhost(%__MODULE__{labels: labels}, port_index),
     do: Labels.marathon_lb_vhost(labels, port_index)
 
@@ -54,7 +63,7 @@ defmodule Relay.Marathon.App do
   def marathon_lb_redirect_to_https?(%__MODULE__{labels: labels}, port_index),
     do: Labels.marathon_lb_redirect_to_https?(labels, port_index)
 
-  @spec marathon_acme_domain(t, non_neg_integer) :: [String.t]
+  @spec marathon_acme_domain(t, non_neg_integer) :: [String.t()]
   def marathon_acme_domain(%__MODULE__{labels: labels}, port_index),
     do: Labels.marathon_acme_domain(labels, port_index)
 end

--- a/test/relay/marathon/adapter_test.exs
+++ b/test/relay/marathon/adapter_test.exs
@@ -20,6 +20,7 @@ defmodule Relay.Marathon.AdapterTest do
     },
     networking_mode: :"container/bridge",
     ports_list: [80],
+    port_indices_in_group: [0],
     version: "2017-11-08T15:06:31.066Z"
   }
 
@@ -56,10 +57,10 @@ defmodule Relay.Marathon.AdapterTest do
     end
   end
 
-  describe "app_port_cluster/4" do
+  describe "app_clusters/3" do
     test "simple cluster" do
       eds_type = Cluster.DiscoveryType.value(:EDS)
-      cluster = Adapter.app_port_cluster(@test_app, 0, @test_config_source)
+      assert [cluster] = Adapter.app_clusters(@test_app, @test_config_source)
 
       assert %Cluster{
                name: "/mc2_0",
@@ -79,10 +80,9 @@ defmodule Relay.Marathon.AdapterTest do
       connect_timeout = Duration.new(seconds: 10)
       lb_policy = Cluster.LbPolicy.value(:MAGLEV)
 
-      cluster =
-        Adapter.app_port_cluster(
+      assert [cluster] =
+        Adapter.app_clusters(
           @test_app,
-          0,
           @test_config_source,
           connect_timeout: connect_timeout,
           lb_policy: lb_policy
@@ -105,13 +105,13 @@ defmodule Relay.Marathon.AdapterTest do
     test "cluster with long name" do
       app = %{@test_app | id: "/organisation/my_long_group_name/subgroup3456/application2934"}
 
-      assert %Cluster{name: "[...]ation/my_long_group_name/subgroup3456/application2934_0"} =
-               Adapter.app_port_cluster(app, 0, @test_config_source)
+      assert [%Cluster{name: "[...]ation/my_long_group_name/subgroup3456/application2934_0"}] =
+               Adapter.app_clusters(app, @test_config_source)
     end
 
     test "custom max_obj_name_length" do
       app = %{@test_app | id: "/myslightlylongname"}
-      cluster = Adapter.app_port_cluster(app, 0, @test_config_source, max_obj_name_length: 10)
+      assert [cluster] = Adapter.app_clusters(app, @test_config_source, max_obj_name_length: 10)
 
       assert %Cluster{name: "[...]ame_0"} = cluster
       assert Protobuf.Validator.valid?(cluster)

--- a/test/relay/marathon/adapter_test.exs
+++ b/test/relay/marathon/adapter_test.exs
@@ -180,14 +180,14 @@ defmodule Relay.Marathon.AdapterTest do
     end
   end
 
-  describe "app_port_virtual_host/3" do
+  describe "app_virtual_hosts/3" do
     test "http virtual host" do
       app = %{
         @test_app
         | labels: @test_app.labels |> Map.put("HAPROXY_0_REDIRECT_TO_HTTPS", "false")
       }
 
-      virtual_host = Adapter.app_port_virtual_host(:http, app, 0)
+      assert [virtual_host] = Adapter.app_virtual_hosts(:http, app)
 
       assert %VirtualHost{
                name: "http_/mc2_0",
@@ -209,7 +209,7 @@ defmodule Relay.Marathon.AdapterTest do
         | labels: @test_app.labels |> Map.put("HAPROXY_0_REDIRECT_TO_HTTPS", "false")
       }
 
-      virtual_host = Adapter.app_port_virtual_host(:https, app, 0)
+      assert [virtual_host] = Adapter.app_virtual_hosts(:https, app)
 
       assert %VirtualHost{
                name: "https_/mc2_0",
@@ -235,11 +235,10 @@ defmodule Relay.Marathon.AdapterTest do
         | labels: @test_app.labels |> Map.put("HAPROXY_0_REDIRECT_TO_HTTPS", "false")
       }
 
-      virtual_host =
-        Adapter.app_port_virtual_host(
+      assert [virtual_host] =
+        Adapter.app_virtual_hosts(
           :http,
           app,
-          0,
           response_headers_to_add: [
             HeaderValueOption.new(
               header: HeaderValue.new(key: "Strict-Transport-Security", value: "max-age=31536000")
@@ -293,7 +292,7 @@ defmodule Relay.Marathon.AdapterTest do
     end
 
     test "http to https redirect" do
-      virtual_host = Adapter.app_port_virtual_host(:http, @test_app, 0)
+      assert [virtual_host] = Adapter.app_virtual_hosts(:http, @test_app)
 
       assert %VirtualHost{
                name: "http_/mc2_0",
@@ -311,7 +310,7 @@ defmodule Relay.Marathon.AdapterTest do
 
     test "other listeners rejected" do
       assert_raise ArgumentError, "only :http and :https listeners supported", fn ->
-        Adapter.app_port_virtual_host(:ftp, @test_app, 0)
+        Adapter.app_virtual_hosts(:ftp, @test_app)
       end
     end
   end

--- a/test/relay/marathon/adapter_test.exs
+++ b/test/relay/marathon/adapter_test.exs
@@ -204,12 +204,7 @@ defmodule Relay.Marathon.AdapterTest do
     end
 
     test "https virtual host" do
-      app = %{
-        @test_app
-        | labels: @test_app.labels |> Map.put("HAPROXY_0_REDIRECT_TO_HTTPS", "false")
-      }
-
-      assert [virtual_host] = Adapter.app_virtual_hosts(:https, app)
+      assert [virtual_host] = Adapter.app_virtual_hosts(:https, @test_app)
 
       assert %VirtualHost{
                name: "https_/mc2_0",

--- a/test/relay/marathon/adapter_test.exs
+++ b/test/relay/marathon/adapter_test.exs
@@ -118,9 +118,9 @@ defmodule Relay.Marathon.AdapterTest do
     end
   end
 
-  describe "app_port_cluster_load_assignment/4" do
+  describe "app_cluster_load_assignments/3" do
     test "simple cluster load assignment" do
-      cla = Adapter.app_port_cluster_load_assignment(@test_app, [@test_task], 0)
+      assert [cla] = Adapter.app_cluster_load_assignments(@test_app, [@test_task])
 
       assert %ClusterLoadAssignment{
                cluster_name: "/mc2_0",
@@ -151,11 +151,10 @@ defmodule Relay.Marathon.AdapterTest do
     test "cluster load assignment with options" do
       alias Google.Protobuf.{UInt32Value, UInt64Value}
 
-      cla =
-        Adapter.app_port_cluster_load_assignment(
+      assert [cla] =
+        Adapter.app_cluster_load_assignments(
           @test_app,
           [@test_task],
-          0,
           policy: ClusterLoadAssignment.Policy.new(drop_overload: 5.0),
           locality_lb_endpoints_opts: [
             load_balancing_weight: UInt64Value.new(value: 42),

--- a/test/relay/marathon/app_test.exs
+++ b/test/relay/marathon/app_test.exs
@@ -146,7 +146,7 @@ defmodule Relay.Marathon.AppTest do
   }
 
   test "from definition" do
-    assert App.from_definition(@test_app) == %App{
+    assert App.from_definition(@test_app, "external") == %App{
       id: "/mc2",
       labels: %{
         "HAPROXY_0_REDIRECT_TO_HTTPS" => "true",
@@ -156,29 +156,29 @@ defmodule Relay.Marathon.AppTest do
       },
       networking_mode: :"container/bridge",
       ports_list: [80],
+      port_indices_in_group: [0],
       version: "2017-11-08T15:06:31.066Z"
     }
   end
 
   test "from event" do
-    assert App.from_event(@test_event) == %App{
+    assert App.from_event(@test_event, "external") == %App{
       id: "/jamie-event-test",
       labels: %{},
       networking_mode: :host,
       ports_list: [0],
+      port_indices_in_group: [],
       version: "2018-03-02T09:31:54.763Z"
     }
   end
 
   test "port indices in group" do
-    app = App.from_definition(@test_app)
-
-    assert App.port_indices_in_group(app, "internal") == []
-    assert App.port_indices_in_group(app, "external") == [0]
+    assert %App{port_indices_in_group: []} = App.from_definition(@test_app, "internal")
+    assert %App{port_indices_in_group: [0]} = App.from_definition(@test_app, "external")
   end
 
   test "label getters" do
-    app = App.from_definition(@test_app)
+    app = App.from_definition(@test_app, "external")
 
     assert App.marathon_lb_vhost(app, 0) == ["mc2.example.org"]
     assert App.marathon_lb_vhost(app, 1) == []

--- a/test/relay/marathon/state_test.exs
+++ b/test/relay/marathon/state_test.exs
@@ -13,6 +13,7 @@ defmodule Relay.Marathon.StateTest do
     },
     networking_mode: :"container/bridge",
     ports_list: [80],
+    port_indices_in_group: [0],
     version: "2017-11-08T15:06:31.066Z"
   }
 

--- a/test/relay/marathon/task_test.exs
+++ b/test/relay/marathon/task_test.exs
@@ -13,6 +13,7 @@ defmodule Relay.Marathon.TaskTest do
     },
     networking_mode: :"container/bridge",
     ports_list: [80],
+    port_indices_in_group: [0],
     version: "2017-11-08T15:06:31.066Z"
   }
 


### PR DESCRIPTION
* Add Adapter functions to work with the new information and return lists of `Cluster`s/`ClusterLoadAssignment`s/`VirtualHost`s for each App.

This does throw away some flexibility in terms of having different config options for different port indices on a single app.

It may also be easier to create `RouteConfiguration`s from `App`s now... 