### PR TITLE
Initial configuration implementation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -40,6 +40,10 @@ config :relay, [
     max_obj_name_length: 60,
     listeners: [
       http: [
+        listen: [
+          address: "127.0.0.1",
+          port: 8080
+        ],
         http_connection_manager: [
           access_log: [
             path: "http_access.log",
@@ -56,6 +60,10 @@ config :relay, [
         ]
       ],
       https: [
+        listen: [
+          address: "127.0.0.1",
+          port: 8443
+        ],
         http_connection_manager: [
           access_log: [
             path: "https_access.log",

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,12 @@ use Mix.Config
 
 config :relay, [
   port: 5000,
-  cluster_name: "xds_cluster",
+
+  envoy: [
+    cluster_name: "xds_cluster",
+    max_obj_name_length: 60
+  ],
+
   marathon: [
     urls: ["http://localhost:8080"],
     events_timeout: 60_000

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,3 +28,21 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
+
+config :relay, [
+  port: 5000,
+  cluster_name: "xds_cluster",
+  marathon: [
+    urls: ["http://localhost:8080"],
+    events_timeout: 60_000
+  ],
+
+  marathon_lb: [
+    group: "external"
+  ],
+
+  marathon_acme: [
+    app_id: "/marathon-acme",
+    port_index: 0
+  ]
+]

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,7 @@ use Mix.Config
 
 config :relay, [
   listen: [
-    address: {127, 0, 0, 1},
+    address: "127.0.0.1",
     port: 5000
   ],
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -37,7 +37,41 @@ config :relay, [
 
   envoy: [
     cluster_name: "xds_cluster",
-    max_obj_name_length: 60
+    max_obj_name_length: 60,
+    listeners: [
+      http: [
+        http_connection_manager: [
+          access_log: [
+            path: "http_access.log",
+            format: ""
+            # TODO: Figure out how to configure filters
+          ]
+        ],
+        router: [
+          upstream_log: [
+            path: "http_upstream.log",
+            format: ""
+            # TODO: Figure out how to configure filters
+          ]
+        ]
+      ],
+      https: [
+        http_connection_manager: [
+          access_log: [
+            path: "https_access.log",
+            format: ""
+            # TODO: Figure out how to configure filters
+          ]
+        ],
+        router: [
+          upstream_log: [
+            path: "https_upstream.log",
+            format: ""
+            # TODO: Figure out how to configure filters
+          ]
+        ]
+      ]
+    ]
   ],
 
   marathon: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,10 @@ use Mix.Config
 #     import_config "#{Mix.env}.exs"
 
 config :relay, [
-  port: 5000,
+  listen: [
+    address: {127, 0, 0, 1},
+    port: 5000
+  ],
 
   envoy: [
     cluster_name: "xds_cluster",

--- a/config/relay.dev.conf
+++ b/config/relay.dev.conf
@@ -10,6 +10,18 @@ relay.envoy.cluster_name = "xds_cluster"
 # The maximum length of Envoy object names
 relay.envoy.max_obj_name_length = 60
 
+# Path to the access log file for incoming connections
+# relay.envoy.listeners.*.http_connection_manager.access_log.path =
+
+# Format for the access log for incoming connections
+# relay.envoy.listeners.*.http_connection_manager.access_log.format =
+
+# Path to the access log file for outgoing connections
+# relay.envoy.listeners.*.router.upstream_log.path =
+
+# Format for the access log for outgoing connections
+# relay.envoy.listeners.*.router.upstream_log.format =
+
 # URLs for Marathon's API endpoints
 relay.marathon.urls = "http://localhost:8080"
 

--- a/config/relay.dev.conf
+++ b/config/relay.dev.conf
@@ -1,0 +1,20 @@
+# Port for discovery service to listen on
+relay.port = 5000
+
+# The cluster name for this discovery service in Envoy's bootstrap.yaml
+relay.cluster_name = "xds_cluster"
+
+# URLs for Marathon's API endpoints
+relay.marathon.urls = "http://localhost:8080"
+
+# Timeout value for Marathon's event stream
+relay.marathon.events_timeout = 60000
+
+# The marathon-lb group to expose via Envoy
+relay.marathon_lb.group = "external"
+
+# The Marathon app ID for marathon-acme
+relay.marathon_acme.app_id = "/marathon-acme"
+
+# The port index for marathon-acme
+relay.marathon_acme.port_index = 0

--- a/config/relay.dev.conf
+++ b/config/relay.dev.conf
@@ -2,7 +2,10 @@
 relay.port = 5000
 
 # The cluster name for this discovery service in Envoy's bootstrap.yaml
-relay.cluster_name = "xds_cluster"
+relay.envoy.cluster_name = "xds_cluster"
+
+# The maximum length of Envoy object names
+relay.envoy.max_obj_name_length = 60
 
 # URLs for Marathon's API endpoints
 relay.marathon.urls = "http://localhost:8080"

--- a/config/relay.dev.conf
+++ b/config/relay.dev.conf
@@ -1,5 +1,8 @@
+# Address to interface for discovery service to listen on
+relay.listen.address = "127.0.0.1"
+
 # Port for discovery service to listen on
-relay.port = 5000
+relay.listen.port = 5000
 
 # The cluster name for this discovery service in Envoy's bootstrap.yaml
 relay.envoy.cluster_name = "xds_cluster"

--- a/config/relay.dev.conf
+++ b/config/relay.dev.conf
@@ -10,6 +10,12 @@ relay.envoy.cluster_name = "xds_cluster"
 # The maximum length of Envoy object names
 relay.envoy.max_obj_name_length = 60
 
+# Address to interface for listener to listen on
+# relay.envoy.listeners.*.listen.address = "127.0.0.1"
+
+# Port for listener to listen on
+# relay.envoy.listeners.*.listen.port =
+
 # Path to the access log file for incoming connections
 # relay.envoy.listeners.*.http_connection_manager.access_log.path =
 

--- a/config/relay.schema.exs
+++ b/config/relay.schema.exs
@@ -1,0 +1,118 @@
+@moduledoc """
+A schema is a keyword list which represents how to map, transform, and validate
+configuration values parsed from the .conf file. The following is an explanation of
+each key in the schema definition in order of appearance, and how to use them.
+
+## Import
+
+A list of application names (as atoms), which represent apps to load modules from
+which you can then reference in your schema definition. This is how you import your
+own custom Validator/Transform modules, or general utility modules for use in
+validator/transform functions in the schema. For example, if you have an application
+`:foo` which contains a custom Transform module, you would add it to your schema like so:
+
+`[ import: [:foo], ..., transforms: ["myapp.some.setting": MyApp.SomeTransform]]`
+
+## Extends
+
+A list of application names (as atoms), which contain schemas that you want to extend
+with this schema. By extending a schema, you effectively re-use definitions in the
+extended schema. You may also override definitions from the extended schema by redefining them
+in the extending schema. You use `:extends` like so:
+
+`[ extends: [:foo], ... ]`
+
+## Mappings
+
+Mappings define how to interpret settings in the .conf when they are translated to
+runtime configuration. They also define how the .conf will be generated, things like
+documention, @see references, example values, etc.
+
+See the moduledoc for `Conform.Schema.Mapping` for more details.
+
+## Transforms
+
+Transforms are custom functions which are executed to build the value which will be
+stored at the path defined by the key. Transforms have access to the current config
+state via the `Conform.Conf` module, and can use that to build complex configuration
+from a combination of other config values.
+
+See the moduledoc for `Conform.Schema.Transform` for more details and examples.
+
+## Validators
+
+Validators are simple functions which take two arguments, the value to be validated,
+and arguments provided to the validator (used only by custom validators). A validator
+checks the value, and returns `:ok` if it is valid, `{:warn, message}` if it is valid,
+but should be brought to the users attention, or `{:error, message}` if it is invalid.
+
+See the moduledoc for `Conform.Schema.Validator` for more details and examples.
+"""
+[
+  extends: [],
+  import: [],
+  mappings: [
+    "relay.port": [
+      commented: false,
+      datatype: :integer,
+      default: 5000,
+      doc: "Port for discovery service to listen on",
+      hidden: false,
+      to: "relay.port"
+    ],
+    "relay.cluster_name": [
+      commented: false,
+      datatype: :binary,
+      default: "xds_cluster",
+      doc: "The cluster name for this discovery service in Envoy's bootstrap.yaml",
+      hidden: false,
+      to: "relay.cluster_name"
+    ],
+    "relay.marathon.urls": [
+      commented: false,
+      datatype: [
+        list: :binary
+      ],
+      default: [
+        "http://localhost:8080"
+      ],
+      doc: "URLs for Marathon's API endpoints",
+      hidden: false,
+      to: "relay.marathon.urls"
+    ],
+    "relay.marathon.events_timeout": [
+      commented: false,
+      datatype: :integer,
+      default: 60000,
+      doc: "Timeout value for Marathon's event stream",
+      hidden: false,
+      to: "relay.marathon.events_timeout"
+    ],
+    "relay.marathon_lb.group": [
+      commented: false,
+      datatype: :binary,
+      default: "external",
+      doc: "The marathon-lb group to expose via Envoy",
+      hidden: false,
+      to: "relay.marathon_lb.group"
+    ],
+    "relay.marathon_acme.app_id": [
+      commented: false,
+      datatype: :binary,
+      default: "/marathon-acme",
+      doc: "The Marathon app ID for marathon-acme",
+      hidden: false,
+      to: "relay.marathon_acme.app_id"
+    ],
+    "relay.marathon_acme.port_index": [
+      commented: false,
+      datatype: :integer,
+      default: 0,
+      doc: "The port index for marathon-acme",
+      hidden: false,
+      to: "relay.marathon_acme.port_index"
+    ]
+  ],
+  transforms: [],
+  validators: []
+]

--- a/config/relay.schema.exs
+++ b/config/relay.schema.exs
@@ -84,6 +84,40 @@ See the moduledoc for `Conform.Schema.Validator` for more details and examples.
       hidden: false,
       to: "relay.envoy.max_obj_name_length"
     ],
+    "relay.envoy.listeners.*": [
+      datatype: [list: :complex],
+      default: [],
+      hidden: true,
+      to: "relay.envoy.listeners"
+    ],
+    "relay.envoy.listeners.*.http_connection_manager.access_log.path": [
+      commented: false,
+      datatype: :binary,
+      doc: "Path to the access log file for incoming connections",
+      hidden: false,
+      to: "relay.envoy.listeners"
+    ],
+    "relay.envoy.listeners.*.http_connection_manager.access_log.format": [
+      commented: false,
+      datatype: :binary,
+      doc: "Format for the access log for incoming connections",
+      hidden: false,
+      to: "relay.envoy.listeners"
+    ],
+    "relay.envoy.listeners.*.router.upstream_log.path": [
+      commented: false,
+      datatype: :binary,
+      doc: "Path to the access log file for outgoing connections",
+      hidden: false,
+      to: "relay.envoy.listeners"
+    ],
+    "relay.envoy.listeners.*.router.upstream_log.format": [
+      commented: false,
+      datatype: :binary,
+      doc: "Format for the access log for outgoing connections",
+      hidden: false,
+      to: "relay.envoy.listeners"
+    ],
     "relay.marathon.urls": [
       commented: false,
       datatype: [

--- a/config/relay.schema.exs
+++ b/config/relay.schema.exs
@@ -136,12 +136,8 @@ See the moduledoc for `Conform.Schema.Validator` for more details and examples.
     ],
     "relay.marathon.urls": [
       commented: false,
-      datatype: [
-        list: :binary
-      ],
-      default: [
-        "http://localhost:8080"
-      ],
+      datatype: [list: :binary],
+      default: ["http://localhost:8080"],
       doc: "URLs for Marathon's API endpoints",
       hidden: false,
       to: "relay.marathon.urls"

--- a/config/relay.schema.exs
+++ b/config/relay.schema.exs
@@ -52,13 +52,21 @@ See the moduledoc for `Conform.Schema.Validator` for more details and examples.
   extends: [],
   import: [],
   mappings: [
-    "relay.port": [
+    "relay.listen.address": [
+      commented: false,
+      datatype: :binary,
+      default: "127.0.0.1",
+      doc: "Address to interface for discovery service to listen on",
+      hidden: false,
+      to: "relay.listen.address"
+    ],
+    "relay.listen.port": [
       commented: false,
       datatype: :integer,
       default: 5000,
       doc: "Port for discovery service to listen on",
       hidden: false,
-      to: "relay.port"
+      to: "relay.listen.port"
     ],
     "relay.envoy.cluster_name": [
       commented: false,
@@ -121,6 +129,13 @@ See the moduledoc for `Conform.Schema.Validator` for more details and examples.
       to: "relay.marathon_acme.port_index"
     ]
   ],
-  transforms: [],
+  transforms: [
+    "relay.listen.address": fn conf ->
+      [{_, str_address}] = Conform.Conf.get(conf, "relay.listen.address")
+      {:ok, address} = String.to_charlist(str_address) |> :inet.parse_address()
+
+      address
+    end
+  ],
   validators: []
 ]

--- a/config/relay.schema.exs
+++ b/config/relay.schema.exs
@@ -90,6 +90,22 @@ See the moduledoc for `Conform.Schema.Validator` for more details and examples.
       hidden: true,
       to: "relay.envoy.listeners"
     ],
+    "relay.envoy.listeners.*.listen.address": [
+      commented: true,
+      # These addresses aren't transformed because Envoy takes binary addresses
+      datatype: :binary,
+      default: "127.0.0.1",
+      doc: "Address to interface for listener to listen on",
+      hidden: false,
+      to: "relay.envoy.listeners"
+    ],
+    "relay.envoy.listeners.*.listen.port": [
+      commented: false,
+      datatype: :integer,
+      doc: "Port for listener to listen on",
+      hidden: false,
+      to: "relay.envoy.listeners"
+    ],
     "relay.envoy.listeners.*.http_connection_manager.access_log.path": [
       commented: false,
       datatype: :binary,

--- a/config/relay.schema.exs
+++ b/config/relay.schema.exs
@@ -179,13 +179,6 @@ See the moduledoc for `Conform.Schema.Validator` for more details and examples.
       to: "relay.marathon_acme.port_index"
     ]
   ],
-  transforms: [
-    "relay.listen.address": fn conf ->
-      [{_, str_address}] = Conform.Conf.get(conf, "relay.listen.address")
-      {:ok, address} = String.to_charlist(str_address) |> :inet.parse_address()
-
-      address
-    end
-  ],
+  transforms: [],
   validators: []
 ]

--- a/config/relay.schema.exs
+++ b/config/relay.schema.exs
@@ -60,13 +60,21 @@ See the moduledoc for `Conform.Schema.Validator` for more details and examples.
       hidden: false,
       to: "relay.port"
     ],
-    "relay.cluster_name": [
+    "relay.envoy.cluster_name": [
       commented: false,
       datatype: :binary,
       default: "xds_cluster",
       doc: "The cluster name for this discovery service in Envoy's bootstrap.yaml",
       hidden: false,
-      to: "relay.cluster_name"
+      to: "relay.envoy.cluster_name"
+    ],
+    "relay.envoy.max_obj_name_length": [
+      commented: false,
+      datatype: :integer,
+      default: 60,
+      doc: "The maximum length of Envoy object names",
+      hidden: false,
+      to: "relay.envoy.max_obj_name_length"
     ],
     "relay.marathon.urls": [
       commented: false,

--- a/lib/relay.ex
+++ b/lib/relay.ex
@@ -8,8 +8,11 @@ defmodule Relay do
   alias Relay.Supervisor
 
   def start(_type, _args) do
-    port = Application.get_env(:relay, :port, 5000)
-    Supervisor.start_link({port}, name: Supervisor)
+    listen = Application.fetch_env!(:relay, :listen)
+    addr = Keyword.get(listen, :address)
+    port = Keyword.get(listen, :port)
+
+    Supervisor.start_link({addr, port}, name: Supervisor)
   end
 
 end

--- a/lib/relay/demo/certs.ex
+++ b/lib/relay/demo/certs.ex
@@ -162,8 +162,8 @@ defmodule Relay.Demo.Certs do
   def listeners do
     https_filter_chains = Enum.map([@demo_pem], &https_filter_chain/1)
     [
-      listener("http", EnvoyUtil.socket_address("0.0.0.0", 8080), [filter_chain("http")]),
-      listener("https", EnvoyUtil.socket_address("0.0.0.0", 8443), https_filter_chains),
+      listener("http", EnvoyUtil.listener_address(:http), [filter_chain("http")]),
+      listener("https", EnvoyUtil.listener_address(:https), https_filter_chains),
     ]
   end
 end

--- a/lib/relay/demo/certs.ex
+++ b/lib/relay/demo/certs.ex
@@ -95,7 +95,7 @@ defmodule Relay.Demo.Certs do
       name: "envoy.router",
       config: mkstruct(
         # FIXME: Don't do this name to atom thing
-        Router.new(upstream_log: String.to_atom(name) |> EnvoyUtil.router_upstream_log())
+        Router.new(upstream_log: String.to_existing_atom(name) |> EnvoyUtil.router_upstream_log())
       )
     )
   end
@@ -115,7 +115,8 @@ defmodule Relay.Demo.Certs do
           stat_prefix: name,
           http_filters: [router_filter(name)],
           # FIXME: Don't do this name to atom thing
-          access_log: String.to_atom(name) |> EnvoyUtil.http_connection_manager_access_log()
+          access_log:
+            String.to_existing_atom(name) |> EnvoyUtil.http_connection_manager_access_log()
         )
       )
     )

--- a/lib/relay/demo/certs.ex
+++ b/lib/relay/demo/certs.ex
@@ -87,12 +87,6 @@ defmodule Relay.Demo.Certs do
     %{state | version: state.version + 1}
   end
 
-  defp socket_address(address, port) do
-    alias Envoy.Api.V2.Core.{Address, SocketAddress}
-    sock = SocketAddress.new(address: address, port_specifier: {:port_value, port})
-    Address.new(address: {:socket_address, sock})
-  end
-
   defp router_filter do
     alias Envoy.Config.Filter.Network.HttpConnectionManager.V2.HttpFilter
     alias Envoy.Config.Filter.Http.Router.V2.Router
@@ -164,8 +158,8 @@ defmodule Relay.Demo.Certs do
   def listeners do
     https_filter_chains = Enum.map([@demo_pem], &https_filter_chain/1)
     [
-      listener("http", socket_address("0.0.0.0", 8080), [filter_chain("http")]),
-      listener("https", socket_address("0.0.0.0", 8443), https_filter_chains),
+      listener("http", EnvoyUtil.socket_address("0.0.0.0", 8080), [filter_chain("http")]),
+      listener("https", EnvoyUtil.socket_address("0.0.0.0", 8443), https_filter_chains),
     ]
   end
 end

--- a/lib/relay/demo/marathon.ex
+++ b/lib/relay/demo/marathon.ex
@@ -63,24 +63,8 @@ defmodule Relay.Demo.Marathon do
     %{state | version: state.version + 1}
   end
 
-  defp own_api_config_source do
-    alias Envoy.Api.V2.Core.{ApiConfigSource, ConfigSource, GrpcService}
-    ConfigSource.new(config_source_specifier: {:api_config_source, ApiConfigSource.new(
-      api_type: ApiConfigSource.ApiType.value(:GRPC),
-      # TODO: Make our cluster name configurable--this must match the cluster
-      # name in bootstrap.yaml
-      # TODO: I don't understand what grpc_services is for when there is a
-      # `cluster_names`. `cluster_names` is required.
-      cluster_names: ["xds_cluster"],
-      grpc_services: [
-        GrpcService.new(target_specifier:
-          {:envoy_grpc, GrpcService.EnvoyGrpc.new(cluster_name: "xds_cluster")})
-      ]
-    )})
-  end
-
   def clusters do
-    Adapter.app_clusters(@demo_app, own_api_config_source())
+    Adapter.app_clusters(@demo_app)
   end
 
   def routes do

--- a/lib/relay/envoy_util.ex
+++ b/lib/relay/envoy_util.ex
@@ -1,5 +1,5 @@
 defmodule Relay.EnvoyUtil do
-  alias Envoy.Api.V2.Core.{ApiConfigSource, ConfigSource}
+  alias Envoy.Api.V2.Core.{Address, ApiConfigSource, ConfigSource, SocketAddress}
 
   @truncated_name_prefix "[...]"
 
@@ -39,5 +39,11 @@ defmodule Relay.EnvoyUtil do
       _ ->
         name
     end
+  end
+
+  @spec socket_address(String.t, :inet.port_number) :: Address.t
+  def socket_address(address, port) do
+    sock = SocketAddress.new(address: address, port_specifier: {:port_value, port})
+    Address.new(address: {:socket_address, sock})
   end
 end

--- a/lib/relay/envoy_util.ex
+++ b/lib/relay/envoy_util.ex
@@ -1,9 +1,11 @@
 defmodule Relay.EnvoyUtil do
   alias Envoy.Api.V2.Core.{ApiConfigSource, ConfigSource}
 
-  @spec api_config_source(keyword) :: ConfigSource.t
+  @truncated_name_prefix "[...]"
+
+  @spec api_config_source(keyword) :: ConfigSource.t()
   def api_config_source(options \\ []) do
-    cluster_name = Application.fetch_env!(:relay, :cluster_name)
+    cluster_name = Application.fetch_env!(:relay, :envoy) |> Keyword.fetch!(:cluster_name)
 
     ConfigSource.new(
       config_source_specifier:
@@ -15,5 +17,27 @@ defmodule Relay.EnvoyUtil do
            ] ++ options
          )}
     )
+  end
+
+  @doc """
+  Truncate an object name to within the Envoy limit. Envoy has limits on the
+  size of the value for the name field for Cluster/RouteConfiguration/Listener
+  objects.
+
+  https://www.envoyproxy.io/docs/envoy/v1.5.0/operations/cli.html#cmdoption-max-obj-name-len
+  """
+  @spec truncate_obj_name(String.t()) :: String.t()
+  def truncate_obj_name(name) do
+    max_size = Application.fetch_env!(:relay, :envoy) |> Keyword.fetch!(:max_obj_name_length)
+
+    case byte_size(name) do
+      size when size > max_size ->
+        truncated_size = max_size - byte_size(@truncated_name_prefix)
+        truncated_name = name |> binary_part(size, -truncated_size)
+        "#{@truncated_name_prefix}#{truncated_name}"
+
+      _ ->
+        name
+    end
   end
 end

--- a/lib/relay/envoy_util.ex
+++ b/lib/relay/envoy_util.ex
@@ -44,6 +44,12 @@ defmodule Relay.EnvoyUtil do
     end
   end
 
+  @spec listener_address(atom) :: Address.t()
+  def listener_address(listener) do
+    listen = Application.fetch_env!(:relay, :envoy) |> get_in([:listeners, listener, :listen])
+    socket_address(Keyword.fetch!(listen, :address), Keyword.fetch!(listen, :port))
+  end
+
   @spec socket_address(String.t(), :inet.port_number()) :: Address.t()
   def socket_address(address, port) do
     sock = SocketAddress.new(address: address, port_specifier: {:port_value, port})

--- a/lib/relay/envoy_util.ex
+++ b/lib/relay/envoy_util.ex
@@ -1,0 +1,18 @@
+defmodule Relay.EnvoyUtil do
+  def api_config_source(options \\ []) do
+    alias Envoy.Api.V2.Core.{ApiConfigSource, ConfigSource}
+
+    cluster_name = Application.fetch_env!(:relay, :cluster_name)
+
+    ConfigSource.new(
+      config_source_specifier:
+        {:api_config_source,
+         ApiConfigSource.new(
+           [
+             api_type: ApiConfigSource.ApiType.value(:GRPC),
+             cluster_names: [cluster_name]
+           ] ++ options
+         )}
+    )
+  end
+end

--- a/lib/relay/envoy_util.ex
+++ b/lib/relay/envoy_util.ex
@@ -1,7 +1,8 @@
 defmodule Relay.EnvoyUtil do
-  def api_config_source(options \\ []) do
-    alias Envoy.Api.V2.Core.{ApiConfigSource, ConfigSource}
+  alias Envoy.Api.V2.Core.{ApiConfigSource, ConfigSource}
 
+  @spec api_config_source(keyword) :: ConfigSource.t
+  def api_config_source(options \\ []) do
     cluster_name = Application.fetch_env!(:relay, :cluster_name)
 
     ConfigSource.new(

--- a/lib/relay/envoy_util.ex
+++ b/lib/relay/envoy_util.ex
@@ -41,7 +41,7 @@ defmodule Relay.EnvoyUtil do
     end
   end
 
-  @spec socket_address(String.t, :inet.port_number) :: Address.t
+  @spec socket_address(String.t(), :inet.port_number()) :: Address.t()
   def socket_address(address, port) do
     sock = SocketAddress.new(address: address, port_specifier: {:port_value, port})
     Address.new(address: {:socket_address, sock})

--- a/lib/relay/marathon/adapter.ex
+++ b/lib/relay/marathon/adapter.ex
@@ -276,6 +276,7 @@ defmodule Relay.Marathon.Adapter do
     ]
   end
 
+  @spec marathon_acme_route() :: Route.t
   defp marathon_acme_route do
     config = Application.fetch_env!(:relay, :marathon_acme)
     # TODO: Does the cluster name here need to be truncated?

--- a/lib/relay/marathon/adapter.ex
+++ b/lib/relay/marathon/adapter.ex
@@ -1,4 +1,5 @@
 defmodule Relay.Marathon.Adapter do
+  alias Relay.EnvoyUtil
   alias Relay.Marathon.{App, Task, Networking}
 
   alias Envoy.Api.V2.{Cluster, ClusterLoadAssignment, RouteConfiguration}
@@ -21,12 +22,10 @@ defmodule Relay.Marathon.Adapter do
   of options set but will be Clusters with EDS endpoint discovery. Additional
   options can be specified using `options`.
   """
-  @spec app_clusters(App.t, ConfigSource.t, keyword) :: [Cluster.t]
-  def app_clusters(
-        %App{port_indices_in_group: port_indices_in_group} = app,
-        %ConfigSource{} = eds_config_source,
-        options \\ []
-      ) do
+  @spec app_clusters(App.t, keyword) :: [Cluster.t]
+  def app_clusters(%App{port_indices_in_group: port_indices_in_group} = app, options \\ []) do
+    eds_config_source = EnvoyUtil.api_config_source()
+
     port_indices_in_group
     |> Enum.map(&app_port_cluster(app, &1, eds_config_source, options))
   end

--- a/lib/relay/marathon/adapter.ex
+++ b/lib/relay/marathon/adapter.ex
@@ -1,9 +1,9 @@
 defmodule Relay.Marathon.Adapter do
   alias Relay.EnvoyUtil
-  alias Relay.Marathon.{App, Task, Networking}
+  alias Relay.Marathon.{App, Task}
 
   alias Envoy.Api.V2.{Cluster, ClusterLoadAssignment, RouteConfiguration}
-  alias Envoy.Api.V2.Core.{Address, ConfigSource, Locality, SocketAddress}
+  alias Envoy.Api.V2.Core.{ConfigSource, Locality}
   alias Envoy.Api.V2.Endpoint.{Endpoint, LbEndpoint, LocalityLbEndpoints}
   alias Envoy.Api.V2.Route.{RedirectAction, Route, RouteAction, RouteMatch, VirtualHost}
 
@@ -103,15 +103,12 @@ defmodule Relay.Marathon.Adapter do
   @spec task_port_lb_endpoint(Task.t, non_neg_integer, keyword) :: LbEndpoint.t
   def task_port_lb_endpoint(%Task{address: address, ports: ports}, port_index, options \\ []) do
     LbEndpoint.new(
-      [endpoint: Endpoint.new(address: socket_address(address, Enum.at(ports, port_index)))] ++
-        options
+      [
+        endpoint: Endpoint.new(
+          address: EnvoyUtil.socket_address(address, Enum.at(ports, port_index))
+        )
+      ] ++ options
     )
-  end
-
-  @spec socket_address(String.t, Networking.port_number) :: Address.t
-  defp socket_address(address, port) do
-    sock = SocketAddress.new(address: address, port_specifier: {:port_value, port})
-    Address.new(address: {:socket_address, sock})
   end
 
   @doc """

--- a/lib/relay/marathon/app.ex
+++ b/lib/relay/marathon/app.ex
@@ -7,7 +7,7 @@ defmodule Relay.Marathon.App do
   @type t :: %__MODULE__{
           id: String.t(),
           networking_mode: Networking.networking_mode(),
-          ports_list: [Networking.port_number()],
+          ports_list: [:inet.port_number()],
           port_indices_in_group: [non_neg_integer],
           labels: Labels.labels(),
           version: String.t()
@@ -36,7 +36,7 @@ defmodule Relay.Marathon.App do
 
   defp port_indices_in_group([], _labels, _group), do: []
 
-  @spec port_indices_in_group([Networking.port_number()], %{String.t() => String.t()}, String.t()) ::
+  @spec port_indices_in_group([:inet.port_number()], %{String.t() => String.t()}, String.t()) ::
           [non_neg_integer]
   defp port_indices_in_group(ports_list, labels, group) do
     0..(length(ports_list) - 1)

--- a/lib/relay/marathon/networking.ex
+++ b/lib/relay/marathon/networking.ex
@@ -5,7 +5,6 @@ defmodule Relay.Marathon.Networking do
   """
 
   @type networking_mode :: :container | :"container/bridge" | :host
-  @type port_number :: 1..65_535
 
   @doc """
   Get the Marathon 1.5-equivalent networking mode for an app across different
@@ -35,7 +34,7 @@ defmodule Relay.Marathon.Networking do
 
   # Ports list
 
-  @spec ports_list(map) :: [port_number]
+  @spec ports_list(map) :: [:inet.port_number]
   def ports_list(app), do: networking_mode(app) |> ports_list(app)
 
   defp ports_list(:host, app), do: port_definitions_ports(app)
@@ -101,7 +100,7 @@ defmodule Relay.Marathon.Networking do
   Get the ports for a task given the app's networking mode and a task
   definition.
   """
-  @spec task_ports(networking_mode, map) :: [port_number] | nil
+  @spec task_ports(networking_mode, map) :: [:inet.port_number] | nil
   def task_ports(:host = _networking_mode, %{"ports" => ports} = _task), do: ports
 
   def task_ports(:"container/bridge", %{"ports" => ports}), do: ports

--- a/lib/relay/marathon/task.ex
+++ b/lib/relay/marathon/task.ex
@@ -6,7 +6,7 @@ defmodule Relay.Marathon.Task do
     id: String.t,
     app_id: String.t,
     address: String.t,
-    ports: [Networking.port_number],
+    ports: [:inet.port_number],
     version: String.t
   }
 
@@ -54,7 +54,7 @@ defmodule Relay.Marathon.Task do
     end
   end
 
-  @spec endpoint(t, non_neg_integer) :: {String.t, Networking.port_number}
+  @spec endpoint(t, non_neg_integer) :: {String.t, :inet.port_number}
   def endpoint(%__MODULE__{address: address, ports: ports}, port_index),
     do: {address, Enum.at(ports, port_index)}
 end

--- a/lib/relay/supervisor.ex
+++ b/lib/relay/supervisor.ex
@@ -34,7 +34,7 @@ defmodule Relay.Supervisor do
         Relay.Server.ClusterDiscoveryService,
         Relay.Server.EndpointDiscoveryService,
       ]
-      opts = [adapter: Relay.GRPCAdapter, ip: addr]
+      opts = [adapter: Relay.GRPCAdapter, ip: parse_ip_address(addr)]
       children = [
         {Relay.Demo.Marathon, []},
         {Relay.Demo.Certs, []},
@@ -42,6 +42,12 @@ defmodule Relay.Supervisor do
       ]
 
       Supervisor.init(children, strategy: :one_for_one)
+    end
+
+    @spec parse_ip_address(String.t()) :: :inet.ip_address()
+    defp parse_ip_address(addr) do
+      {:ok, address} = String.to_charlist(addr) |> :inet.parse_address()
+      address
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -47,6 +47,8 @@ defmodule Relay.MixProject do
 
       {:poison, "~> 3.1"},
 
+      {:conform, "~> 2.2"},
+
       # Test deps.
       {:sse_test_server,
        git: "https://github.com/praekeltfoundation/sse_test_server.git",

--- a/test/relay/envoy_util_test.exs
+++ b/test/relay/envoy_util_test.exs
@@ -5,13 +5,13 @@ defmodule Relay.EnvoyUtilTest do
 
   describe "truncate_obj_name/1" do
     test "long names truncated from beginning" do
-      TestHelpers.swap_env(:relay, :envoy, [max_obj_name_length: 10])
+      TestHelpers.put_env(:relay, :envoy, [max_obj_name_length: 10])
 
       assert EnvoyUtil.truncate_obj_name("helloworldmynameis") == "[...]ameis"
     end
 
     test "short names unchanged" do
-      TestHelpers.swap_env(:relay, :envoy, [max_obj_name_length: 10])
+      TestHelpers.put_env(:relay, :envoy, [max_obj_name_length: 10])
 
       assert EnvoyUtil.truncate_obj_name("hello") == "hello"
     end

--- a/test/relay/envoy_util_test.exs
+++ b/test/relay/envoy_util_test.exs
@@ -1,0 +1,19 @@
+defmodule Relay.EnvoyUtilTest do
+  use ExUnit.Case, async: true
+
+  alias Relay.EnvoyUtil
+
+  describe "truncate_obj_name/1" do
+    test "long names truncated from beginning" do
+      TestHelpers.swap_env(:relay, :envoy, [max_obj_name_length: 10])
+
+      assert EnvoyUtil.truncate_obj_name("helloworldmynameis") == "[...]ameis"
+    end
+
+    test "short names unchanged" do
+      TestHelpers.swap_env(:relay, :envoy, [max_obj_name_length: 10])
+
+      assert EnvoyUtil.truncate_obj_name("hello") == "hello"
+    end
+  end
+end

--- a/test/relay/marathon/adapter_test.exs
+++ b/test/relay/marathon/adapter_test.exs
@@ -277,7 +277,7 @@ defmodule Relay.Marathon.AdapterTest do
         | labels: @test_app.labels |> Map.put("MARATHON_ACME_0_DOMAIN", "mc2.example.org")
       }
       # Change the defaults to ensure we're reading from config
-      TestHelpers.swap_env(:relay, :marathon_acme, [app_id: "/ma", port_index: 1])
+      TestHelpers.put_env(:relay, :marathon_acme, [app_id: "/ma", port_index: 1])
 
       assert [virtual_host] = Adapter.app_virtual_hosts(:http, app)
 

--- a/test/relay/marathon/adapter_test.exs
+++ b/test/relay/marathon/adapter_test.exs
@@ -32,22 +32,6 @@ defmodule Relay.Marathon.AdapterTest do
     version: "2017-11-09T08:43:59.890Z"
   }
 
-  describe "truncate_name/2" do
-    test "long names truncated from beginning" do
-      assert Adapter.truncate_name("helloworldmynameis", 10) == "[...]ameis"
-    end
-
-    test "short names unchanged" do
-      assert Adapter.truncate_name("hello", 10) == "hello"
-    end
-
-    test "max_size must be larger than the prefix length" do
-      assert_raise ArgumentError, "`max_size` must be larger than the prefix length", fn ->
-        Adapter.truncate_name("hello", 3)
-      end
-    end
-  end
-
   describe "app_clusters/3" do
     test "simple cluster" do
       eds_type = Cluster.DiscoveryType.value(:EDS)
@@ -97,14 +81,6 @@ defmodule Relay.Marathon.AdapterTest do
 
       assert [%Cluster{name: "[...]ation/my_long_group_name/subgroup3456/application2934_0"}] =
                Adapter.app_clusters(app)
-    end
-
-    test "custom max_obj_name_length" do
-      app = %{@test_app | id: "/myslightlylongname"}
-      assert [cluster] = Adapter.app_clusters(app, max_obj_name_length: 10)
-
-      assert %Cluster{name: "[...]ame_0"} = cluster
-      assert Protobuf.Validator.valid?(cluster)
     end
   end
 
@@ -301,7 +277,7 @@ defmodule Relay.Marathon.AdapterTest do
         | labels: @test_app.labels |> Map.put("MARATHON_ACME_0_DOMAIN", "mc2.example.org")
       }
       # Change the defaults to ensure we're reading from config
-      Application.put_env(:relay, :marathon_acme, [app_id: "/ma", port_index: 1])
+      TestHelpers.swap_env(:relay, :marathon_acme, [app_id: "/ma", port_index: 1])
 
       assert [virtual_host] = Adapter.app_virtual_hosts(:http, app)
 

--- a/test/relay/marathon/adapter_test.exs
+++ b/test/relay/marathon/adapter_test.exs
@@ -148,9 +148,7 @@ defmodule Relay.Marathon.AdapterTest do
 
   describe "app_virtual_hosts/3" do
     test "http virtual host" do
-      app = @test_app
-
-      assert [virtual_host] = Adapter.app_virtual_hosts(:http, app)
+      assert [virtual_host] = Adapter.app_virtual_hosts(:http, @test_app)
 
       assert %VirtualHost{
                name: "http_/mc2_0",

--- a/test/relay/supervisor_test.exs
+++ b/test/relay/supervisor_test.exs
@@ -16,7 +16,7 @@ defmodule Relay.SupervisorTest do
   setup do
     TestHelpers.setup_apps([:grpc])
     TestHelpers.override_log_level(:warn)
-    Application.put_env(:grpc, :start_server, true)
+    TestHelpers.put_env(:grpc, :start_server, true)
 
     {:ok, sup} = start_supervised({Supervisor, {@port}})
     %{supervisor: sup}

--- a/test/relay/supervisor_test.exs
+++ b/test/relay/supervisor_test.exs
@@ -11,6 +11,7 @@ defmodule Relay.SupervisorTest do
 
   import ExUnit.CaptureLog
 
+  @addr "127.0.0.1"
   @port 12345
 
   setup do
@@ -18,7 +19,7 @@ defmodule Relay.SupervisorTest do
     TestHelpers.override_log_level(:warn)
     TestHelpers.put_env(:grpc, :start_server, true)
 
-    {:ok, sup} = start_supervised({Supervisor, {{127, 0, 0, 1}, @port}})
+    {:ok, sup} = start_supervised({Supervisor, {@addr, @port}})
     %{supervisor: sup}
   end
 
@@ -104,7 +105,7 @@ defmodule Relay.SupervisorTest do
 
     {blocker_task, port} = port_blocker(100)
     assert capture_log(fn() ->
-      {:ok, _} = start_supervised({Supervisor, {{127, 0, 0, 1}, port}})
+      {:ok, _} = start_supervised({Supervisor, {@addr, port}})
     end) =~ ~r/Failed to start Ranch listener .* :eaddrinuse/
     Task.await(blocker_task)
   end
@@ -114,7 +115,7 @@ defmodule Relay.SupervisorTest do
 
     {blocker_task, port} = port_blocker(1_050)
     assert capture_log(fn() ->
-      {:error, reason} = start_supervised({Supervisor, {{127, 0, 0, 1}, port}})
+      {:error, reason} = start_supervised({Supervisor, {@addr, port}})
       assert {:listen_error, _, :eaddrinuse} = extract_reason(reason)
     end) =~ ~r/Failed to start Ranch listener .* :eaddrinuse/
     Task.await(blocker_task)

--- a/test/relay_test.exs
+++ b/test/relay_test.exs
@@ -12,8 +12,8 @@ defmodule RelayTest do
 
   setup do
     TestHelpers.override_log_level(:warn)
-    Application.put_env(:grpc, :start_server, true)
-    Application.put_env(:relay, :port, @port, persistent: true)
+    TestHelpers.put_env(:grpc, :start_server, true)
+    TestHelpers.put_env(:relay, :port, @port, persistent: true)
   end
 
   defp stream_xds() do

--- a/test/relay_test.exs
+++ b/test/relay_test.exs
@@ -13,7 +13,7 @@ defmodule RelayTest do
   setup do
     TestHelpers.override_log_level(:warn)
     Application.put_env(:grpc, :start_server, true)
-    Application.put_env(:relay, :port, @port)
+    Application.put_env(:relay, :port, @port, persistent: true)
   end
 
   defp stream_xds() do

--- a/test/relay_test.exs
+++ b/test/relay_test.exs
@@ -13,7 +13,9 @@ defmodule RelayTest do
   setup do
     TestHelpers.override_log_level(:warn)
     TestHelpers.put_env(:grpc, :start_server, true)
-    TestHelpers.put_env(:relay, :port, @port, persistent: true)
+
+    listen = Application.get_env(:relay, :listen) |> Keyword.put(:port, @port)
+    TestHelpers.put_env(:relay, :listen, listen, persistent: true)
   end
 
   defp stream_xds() do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,6 +36,16 @@ defmodule TestHelpers do
     capture_log(fn() -> apps |> Enum.each(&Application.stop/1) end)
   end
 
+  @doc """
+  Set an application configuration option for the duration of the test.
+  """
+  def swap_env(app, key, new_value) do
+    original = Application.get_env(app, key)
+    Application.put_env(app, key, new_value)
+    on_exit(fn -> Application.put_env(app, key, original) end)
+
+    original
+  end
 end
 
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -39,12 +39,12 @@ defmodule TestHelpers do
   @doc """
   Set an application configuration option for the duration of the test.
   """
-  def swap_env(app, key, new_value) do
+  def put_env(app, key, new_value, put_opts \\ []) do
     original = Application.get_env(app, key)
-    Application.put_env(app, key, new_value)
+    Application.put_env(app, key, new_value, put_opts)
     on_exit(fn -> Application.put_env(app, key, original) end)
 
-    original
+    :ok
   end
 end
 


### PR DESCRIPTION
* Add configuration using `conform`
* Use some Envoy-specific config in a new `Relay.EnvoyUtil` module
* Implement the marathon-acme route now that we have the config for it

Config options I've added but not used yet:
* `relay.marathon.urls`
* `relay.marathon.events_timeout`
* `relay.marathon_lb.group` - I could use this in `Relay.Marathon.App` but not sure where the best place to access the value is.