### PR TITLE
Improve configurability of generated Envoy things

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -4,8 +4,10 @@
       name: "default",
       color: true,
       files: %{
-        included: ["config/", "lib/", "test/", "*.exs"],
-        excluded: ["lib/envoy/", "lib/google/"]
+        # The default glob pattern matching doesn't match files starting with a '.'
+        included:
+          ["config/", "lib/", "test/", "*.exs"] ++ Path.wildcard(".*.exs", match_dot: true),
+        excluded: []
       },
       checks: [
         # Don't fail on TODOs and FIXMEs for now

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -6,19 +6,9 @@
 
 include_patterns = ["*.exs", "{config,lib,test}/**/*.{ex,exs}"]
 
-ignore_paths = [
-  # TODO: Reduce this list
-  "config/config.exs"
-]
-
-inputs =
-  Enum.flat_map(include_patterns, fn pattern ->
-    Path.wildcard(pattern, match_dot: true)
-    |> Enum.filter(fn path -> not String.starts_with?(path, ignore_paths) end)
-  end)
-
 [
   import_deps: [:grpc, :protobuf],
-  inputs: inputs,
+  # The default glob pattern matching doesn't match files starting with a '.'
+  inputs: include_patterns |> Enum.flat_map(&Path.wildcard(&1, match_dot: true)),
   locals_without_parens: [xds_tests: 2]
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,14 +1,10 @@
 # Used by "mix format"
 
-# The only way to adjust which files `mix format` considers is with the `input`
-# option. It is possible to have different .formatter.exs files per-directory,
-# but we'd rather not have config in many different files.
-
-include_patterns = ["*.exs", "{config,lib,test}/**/*.{ex,exs}"]
+# The default glob pattern matching doesn't match files starting with a '.'
+inputs = ["*.exs", "{config,lib,test}/**/*.{ex,exs}"] ++ Path.wildcard(".*.exs", match_dot: true)
 
 [
   import_deps: [:grpc, :protobuf],
-  # The default glob pattern matching doesn't match files starting with a '.'
-  inputs: include_patterns |> Enum.flat_map(&Path.wildcard(&1, match_dot: true)),
+  inputs: inputs,
   locals_without_parens: [xds_tests: 2]
 ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -29,12 +29,11 @@ use Mix.Config
 #
 #     import_config "#{Mix.env}.exs"
 
-config :relay, [
+config :relay,
   listen: [
     address: "127.0.0.1",
     port: 5000
   ],
-
   envoy: [
     cluster_name: "xds_cluster",
     max_obj_name_length: 60,
@@ -82,7 +81,6 @@ config :relay, [
     ],
     clusters: [
       connect_timeout: 5_000,
-
       endpoints: [
         locality: [
           region: "default",
@@ -90,20 +88,16 @@ config :relay, [
           sub_zone: ""
         ]
       ]
-    ],
+    ]
   ],
-
   marathon: [
     urls: ["http://localhost:8080"],
     events_timeout: 60_000
   ],
-
   marathon_lb: [
     group: "external"
   ],
-
   marathon_acme: [
     app_id: "/marathon-acme",
     port_index: 0
   ]
-]

--- a/config/config.exs
+++ b/config/config.exs
@@ -81,8 +81,16 @@ config :relay, [
       ]
     ],
     clusters: [
-      connect_timeout: 5_000
-    ]
+      connect_timeout: 5_000,
+
+      endpoints: [
+        locality: [
+          region: "default",
+          zone: "default",
+          sub_zone: ""
+        ]
+      ]
+    ],
   ],
 
   marathon: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -79,6 +79,9 @@ config :relay, [
           ]
         ]
       ]
+    ],
+    clusters: [
+      connect_timeout: 5_000
     ]
   ],
 

--- a/config/relay.dev.conf
+++ b/config/relay.dev.conf
@@ -34,6 +34,9 @@ relay.envoy.max_obj_name_length = 60
 # Format for the access log for outgoing connections
 # relay.envoy.listeners.*.router.upstream_log.format =
 
+# Default connect timeout for upstream clusters (ms)
+relay.envoy.clusters.connect_timeout = 5000
+
 # URLs for Marathon's API endpoints
 relay.marathon.urls = "http://localhost:8080"
 

--- a/config/relay.dev.conf
+++ b/config/relay.dev.conf
@@ -37,10 +37,19 @@ relay.envoy.max_obj_name_length = 60
 # Default connect timeout for upstream clusters (ms)
 relay.envoy.clusters.connect_timeout = 5000
 
+# Default locality region for upstream endpoints
+relay.envoy.clusters.endpoints.locality.region = "default"
+
+# Default locality zone for upstream endpoints
+relay.envoy.clusters.endpoints.locality.zone = "default"
+
+# Default locality sub-zone for upstream endpoints
+relay.envoy.clusters.endpoints.locality.sub_zone = ""
+
 # URLs for Marathon's API endpoints
 relay.marathon.urls = "http://localhost:8080"
 
-# Timeout value for Marathon's event stream
+# Timeout value for Marathon's event stream (ms)
 relay.marathon.events_timeout = 60000
 
 # The marathon-lb group to expose via Envoy

--- a/config/relay.schema.exs
+++ b/config/relay.schema.exs
@@ -156,6 +156,30 @@ See the moduledoc for `Conform.Schema.Validator` for more details and examples.
       hidden: false,
       to: "relay.envoy.clusters.connect_timeout"
     ],
+    "relay.envoy.clusters.endpoints.locality.region": [
+      commented: false,
+      datatype: :binary,
+      default: "default",
+      doc: "Default locality region for upstream endpoints",
+      hidden: false,
+      to: "relay.envoy.clusters.endpoints.locality.region"
+    ],
+    "relay.envoy.clusters.endpoints.locality.zone": [
+      commented: false,
+      datatype: :binary,
+      default: "default",
+      doc: "Default locality zone for upstream endpoints",
+      hidden: false,
+      to: "relay.envoy.clusters.endpoints.locality.zone"
+    ],
+    "relay.envoy.clusters.endpoints.locality.sub_zone": [
+      commented: false,
+      datatype: :binary,
+      default: "",
+      doc: "Default locality sub-zone for upstream endpoints",
+      hidden: false,
+      to: "relay.envoy.clusters.endpoints.locality.sub_zone"
+    ],
     "relay.marathon.urls": [
       commented: false,
       datatype: [list: :binary],

--- a/config/relay.schema.exs
+++ b/config/relay.schema.exs
@@ -148,6 +148,14 @@ See the moduledoc for `Conform.Schema.Validator` for more details and examples.
       hidden: false,
       to: "relay.envoy.listeners"
     ],
+    "relay.envoy.clusters.connect_timeout": [
+      commented: false,
+      datatype: :integer,
+      default: 5_000,
+      doc: "Default connect timeout for upstream clusters (ms)",
+      hidden: false,
+      to: "relay.envoy.clusters.connect_timeout"
+    ],
     "relay.marathon.urls": [
       commented: false,
       datatype: [list: :binary],
@@ -160,7 +168,7 @@ See the moduledoc for `Conform.Schema.Validator` for more details and examples.
       commented: false,
       datatype: :integer,
       default: 60000,
-      doc: "Timeout value for Marathon's event stream",
+      doc: "Timeout value for Marathon's event stream (ms)",
       hidden: false,
       to: "relay.marathon.events_timeout"
     ],

--- a/lib/relay/resources.ex
+++ b/lib/relay/resources.ex
@@ -34,7 +34,10 @@ defmodule Relay.Resources do
       llb_endpoint_opts: [],
       lb_endpoint_opts: [],
       # RDS
-      vhost_opts: []
+      vhost_opts: [],
+      route_opts: [],
+      route_match_opts: [],
+      route_action_opts: []
     ]
 
     @type t :: %__MODULE__{
@@ -47,7 +50,10 @@ defmodule Relay.Resources do
             cla_opts: keyword,
             llb_endpoint_opts: keyword,
             lb_endpoint_opts: keyword,
-            vhost_opts: keyword
+            vhost_opts: keyword,
+            route_opts: keyword,
+            route_match_opts: keyword,
+            route_action_opts: keyword
           }
   end
 

--- a/lib/relay/resources.ex
+++ b/lib/relay/resources.ex
@@ -27,10 +27,14 @@ defmodule Relay.Resources do
       addresses: [],
       marathon_acme_domains: [],
       redirect_to_https: false,
+      # CDS
       cluster_opts: [],
+      # EDS
       cla_opts: [],
       llb_endpoint_opts: [],
-      lb_endpoint_opts: []
+      lb_endpoint_opts: [],
+      # RDS
+      vhost_opts: []
     ]
 
     @type t :: %__MODULE__{
@@ -42,7 +46,8 @@ defmodule Relay.Resources do
             cluster_opts: keyword,
             cla_opts: keyword,
             llb_endpoint_opts: keyword,
-            lb_endpoint_opts: keyword
+            lb_endpoint_opts: keyword,
+            vhost_opts: keyword
           }
   end
 

--- a/lib/relay/resources/cds.ex
+++ b/lib/relay/resources/cds.ex
@@ -35,7 +35,7 @@ defmodule Relay.Resources.CDS do
   end
 
   @spec clusters_config() :: keyword
-  defp clusters_config(), do: fetch_envoy_config!(:clusters)
+  def clusters_config(), do: fetch_envoy_config!(:clusters)
 
   defp fetch_clusters_config!(key), do: clusters_config() |> Keyword.fetch!(key)
 end

--- a/lib/relay/resources/cds.ex
+++ b/lib/relay/resources/cds.ex
@@ -17,8 +17,7 @@ defmodule Relay.Resources.CDS do
 
   @spec cluster(AppEndpoint.t()) :: Cluster.t()
   defp cluster(%AppEndpoint{name: service_name, cluster_opts: options}) do
-    default_connect_timeout = fetch_clusters_config!(:connect_timeout) |> duration()
-    connect_timeout = Keyword.get(options, :connect_timeout, default_connect_timeout)
+    connect_timeout = Keyword.get(options, :connect_timeout, default_connect_timeout())
 
     Cluster.new(
       [
@@ -38,4 +37,7 @@ defmodule Relay.Resources.CDS do
   def clusters_config(), do: fetch_envoy_config!(:clusters)
 
   defp fetch_clusters_config!(key), do: clusters_config() |> Keyword.fetch!(key)
+
+  @spec default_connect_timeout() :: Duration.t()
+  def default_connect_timeout, do: :connect_timeout |> fetch_clusters_config!() |> duration()
 end

--- a/lib/relay/resources/cds.ex
+++ b/lib/relay/resources/cds.ex
@@ -6,6 +6,7 @@ defmodule Relay.Resources.CDS do
   import Relay.Resources.Common
 
   alias Envoy.Api.V2.Cluster
+  alias Google.Protobuf.Duration
 
   @doc """
   Create Clusters for the given app_endpoints.

--- a/lib/relay/resources/cds.ex
+++ b/lib/relay/resources/cds.ex
@@ -2,7 +2,8 @@ defmodule Relay.Resources.CDS do
   @moduledoc """
   Builds Envoy Cluster values from cluster resources.
   """
-  alias Relay.Resources.{AppEndpoint, Common}
+  alias Relay.Resources.AppEndpoint
+  import Relay.Resources.Common
 
   alias Envoy.Api.V2.Cluster
 
@@ -22,11 +23,11 @@ defmodule Relay.Resources.CDS do
   defp cluster(%AppEndpoint{name: service_name, cluster_opts: options}) do
     Cluster.new(
       [
-        name: Common.truncate_obj_name(service_name),
+        name: truncate_obj_name(service_name),
         type: Cluster.DiscoveryType.value(:EDS),
         eds_cluster_config:
           Cluster.EdsClusterConfig.new(
-            eds_config: Common.api_config_source(),
+            eds_config: api_config_source(),
             service_name: service_name
           ),
         connect_timeout: Keyword.get(options, :connect_timeout, @default_cluster_connect_timeout)

--- a/lib/relay/resources/cds.ex
+++ b/lib/relay/resources/cds.ex
@@ -4,6 +4,7 @@ defmodule Relay.Resources.CDS do
   """
   alias Relay.Resources.AppEndpoint
   import Relay.Resources.Common
+  import Relay.Resources.Config, only: [fetch_clusters_config!: 1]
 
   alias Envoy.Api.V2.Cluster
   alias Google.Protobuf.Duration
@@ -33,11 +34,6 @@ defmodule Relay.Resources.CDS do
       ] ++ options
     )
   end
-
-  @spec clusters_config() :: keyword
-  def clusters_config(), do: fetch_envoy_config!(:clusters)
-
-  defp fetch_clusters_config!(key), do: clusters_config() |> Keyword.fetch!(key)
 
   @spec default_connect_timeout() :: Duration.t()
   def default_connect_timeout, do: :connect_timeout |> fetch_clusters_config!() |> duration()

--- a/lib/relay/resources/cds.ex
+++ b/lib/relay/resources/cds.ex
@@ -2,9 +2,8 @@ defmodule Relay.Resources.CDS do
   @moduledoc """
   Builds Envoy Cluster values from cluster resources.
   """
-  alias Relay.Resources.AppEndpoint
+  alias Relay.Resources.{AppEndpoint, Config}
   import Relay.Resources.Common, only: [api_config_source: 0, duration: 1, truncate_obj_name: 1]
-  import Relay.Resources.Config, only: [fetch_clusters_config!: 1]
 
   alias Envoy.Api.V2.Cluster
   alias Google.Protobuf.Duration
@@ -36,5 +35,5 @@ defmodule Relay.Resources.CDS do
   end
 
   @spec default_connect_timeout() :: Duration.t()
-  def default_connect_timeout, do: :connect_timeout |> fetch_clusters_config!() |> duration()
+  def default_connect_timeout, do: :connect_timeout |> Config.fetch_clusters!() |> duration()
 end

--- a/lib/relay/resources/cds.ex
+++ b/lib/relay/resources/cds.ex
@@ -3,7 +3,7 @@ defmodule Relay.Resources.CDS do
   Builds Envoy Cluster values from cluster resources.
   """
   alias Relay.Resources.AppEndpoint
-  import Relay.Resources.Common
+  import Relay.Resources.Common, only: [api_config_source: 0, duration: 1, truncate_obj_name: 1]
   import Relay.Resources.Config, only: [fetch_clusters_config!: 1]
 
   alias Envoy.Api.V2.Cluster

--- a/lib/relay/resources/common.ex
+++ b/lib/relay/resources/common.ex
@@ -2,17 +2,12 @@ defmodule Relay.Resources.Common do
   @moduledoc """
   Common functionality used by multiple resource types.
   """
+  import Relay.Resources.Config, only: [fetch_envoy_config!: 1]
 
   alias Envoy.Api.V2.Core.{Address, ApiConfigSource, ConfigSource, SocketAddress}
   alias Google.Protobuf.Duration
 
   @truncated_name_prefix "[...]"
-
-  @spec envoy_config() :: keyword
-  def envoy_config, do: Application.fetch_env!(:relay, :envoy)
-
-  @spec fetch_envoy_config!(atom) :: any
-  def fetch_envoy_config!(key), do: envoy_config() |> Keyword.fetch!(key)
 
   @spec api_config_source(keyword) :: ConfigSource.t()
   def api_config_source(options \\ []) do

--- a/lib/relay/resources/common.ex
+++ b/lib/relay/resources/common.ex
@@ -2,7 +2,7 @@ defmodule Relay.Resources.Common do
   @moduledoc """
   Common functionality used by multiple resource types.
   """
-  import Relay.Resources.Config, only: [fetch_envoy_config!: 1]
+  alias Relay.Resources.Config
 
   alias Envoy.Api.V2.Core.{Address, ApiConfigSource, ConfigSource, SocketAddress}
   alias Google.Protobuf.Duration
@@ -11,7 +11,7 @@ defmodule Relay.Resources.Common do
 
   @spec api_config_source(keyword) :: ConfigSource.t()
   def api_config_source(options \\ []) do
-    cluster_name = fetch_envoy_config!(:cluster_name)
+    cluster_name = Config.fetch_envoy!(:cluster_name)
 
     ConfigSource.new(
       config_source_specifier:
@@ -34,7 +34,7 @@ defmodule Relay.Resources.Common do
   """
   @spec truncate_obj_name(String.t()) :: String.t()
   def truncate_obj_name(name) do
-    max_size = fetch_envoy_config!(:max_obj_name_length)
+    max_size = Config.fetch_envoy!(:max_obj_name_length)
 
     case byte_size(name) do
       size when size > max_size ->

--- a/lib/relay/resources/common.ex
+++ b/lib/relay/resources/common.ex
@@ -1,5 +1,6 @@
 defmodule Relay.Resources.Common do
   alias Envoy.Api.V2.Core.{Address, ApiConfigSource, ConfigSource, SocketAddress}
+  alias Google.Protobuf.Duration
 
   @truncated_name_prefix "[...]"
 
@@ -51,5 +52,17 @@ defmodule Relay.Resources.Common do
   def socket_address(address, port) do
     sock = SocketAddress.new(address: address, port_specifier: {:port_value, port})
     Address.new(address: {:socket_address, sock})
+  end
+
+  @spec duration(integer) :: Duration.t()
+  def duration(0), do: Duration.new(seconds: 0, nanos: 0)
+
+  def duration(milliseconds) do
+    Duration.new(
+      seconds: div(milliseconds, 1000),
+      # :erlang.rem/2 considers the sign of the nominator, while Integer.mod/2
+      # only considers the sign of the denominator
+      nanos: :erlang.rem(milliseconds, 1000) * 1_000_000
+    )
   end
 end

--- a/lib/relay/resources/common.ex
+++ b/lib/relay/resources/common.ex
@@ -64,7 +64,7 @@ defmodule Relay.Resources.Common do
   def duration(milliseconds) do
     Duration.new(
       seconds: div(milliseconds, 1000),
-      # :erlang.rem/2 considers the sign of the nominator, while Integer.mod/2
+      # :erlang.rem/2 considers the sign of the numerator, while Integer.mod/2
       # only considers the sign of the denominator
       nanos: :erlang.rem(milliseconds, 1000) * 1_000_000
     )

--- a/lib/relay/resources/config.ex
+++ b/lib/relay/resources/config.ex
@@ -2,37 +2,36 @@ defmodule Relay.Resources.Config do
   @moduledoc """
   Common functions for accessing application configuration used in resources.
   """
-  @spec envoy_config() :: keyword
-  defp envoy_config, do: Application.fetch_env!(:relay, :envoy)
+  @spec envoy() :: keyword
+  defp envoy, do: Application.fetch_env!(:relay, :envoy)
 
-  @spec fetch_envoy_config!(atom) :: any
-  def fetch_envoy_config!(key), do: envoy_config() |> Keyword.fetch!(key)
+  @spec fetch_envoy!(atom) :: any
+  def fetch_envoy!(key), do: envoy() |> Keyword.fetch!(key)
 
-  @spec clusters_config() :: keyword
-  defp clusters_config(), do: fetch_envoy_config!(:clusters)
+  @spec clusters() :: keyword
+  defp clusters(), do: fetch_envoy!(:clusters)
 
-  @spec fetch_clusters_config!(atom) :: any
-  def fetch_clusters_config!(key), do: clusters_config() |> Keyword.fetch!(key)
+  @spec fetch_clusters!(atom) :: any
+  def fetch_clusters!(key), do: clusters() |> Keyword.fetch!(key)
 
-  @spec endpoints_config() :: keyword
-  defp endpoints_config, do: fetch_clusters_config!(:endpoints)
+  @spec endpoints() :: keyword
+  defp endpoints, do: fetch_clusters!(:endpoints)
 
-  @spec fetch_endpoints_config!(atom) :: any
-  def fetch_endpoints_config!(key), do: endpoints_config() |> Keyword.fetch!(key)
+  @spec fetch_endpoints!(atom) :: any
+  def fetch_endpoints!(key), do: endpoints() |> Keyword.fetch!(key)
 
-  @spec listener_config(atom) :: keyword
-  defp listener_config(listener), do: fetch_envoy_config!(:listeners) |> Keyword.fetch!(listener)
+  @spec listener(atom) :: keyword
+  defp listener(listener), do: fetch_envoy!(:listeners) |> Keyword.fetch!(listener)
 
-  @spec fetch_listener_config!(atom, atom) :: any
-  def fetch_listener_config!(listener, key),
-    do: listener |> listener_config() |> Keyword.fetch!(key)
+  @spec fetch_listener!(atom, atom) :: any
+  def fetch_listener!(listener, key), do: listener |> listener() |> Keyword.fetch!(key)
 
-  @spec get_listener_config(atom, atom, any) :: any
-  def get_listener_config(listener, key, default),
-    do: listener |> listener_config() |> Keyword.get(key, default)
+  @spec get_listener(atom, atom, any) :: any
+  def get_listener(listener, key, default),
+    do: listener |> listener() |> Keyword.get(key, default)
 
-  @spec marathon_acme_config() :: keyword
-  defp marathon_acme_config, do: Application.fetch_env!(:relay, :marathon_acme)
+  @spec marathon_acme() :: keyword
+  defp marathon_acme, do: Application.fetch_env!(:relay, :marathon_acme)
 
-  def fetch_marathon_acme_config!(key), do: marathon_acme_config() |> Keyword.fetch!(key)
+  def fetch_marathon_acme!(key), do: marathon_acme() |> Keyword.fetch!(key)
 end

--- a/lib/relay/resources/config.ex
+++ b/lib/relay/resources/config.ex
@@ -26,9 +26,9 @@ defmodule Relay.Resources.Config do
   @spec fetch_listener!(atom, atom) :: any
   def fetch_listener!(listener, key), do: listener |> listener() |> Keyword.fetch!(key)
 
-  @spec get_listener(atom, atom, any) :: any
-  def get_listener(listener, key, default),
-    do: listener |> listener() |> Keyword.get(key, default)
+  @spec get_listener_route_config_name(atom) :: String.t()
+  def get_listener_route_config_name(listener),
+    do: listener |> listener() |> Keyword.get(:route_config_name, Atom.to_string(listener))
 
   @spec marathon_acme() :: keyword
   defp marathon_acme, do: Application.fetch_env!(:relay, :marathon_acme)

--- a/lib/relay/resources/config.ex
+++ b/lib/relay/resources/config.ex
@@ -1,0 +1,38 @@
+defmodule Relay.Resources.Config do
+  @moduledoc """
+  Common functions for accessing application configuration used in resources.
+  """
+  @spec envoy_config() :: keyword
+  defp envoy_config, do: Application.fetch_env!(:relay, :envoy)
+
+  @spec fetch_envoy_config!(atom) :: any
+  def fetch_envoy_config!(key), do: envoy_config() |> Keyword.fetch!(key)
+
+  @spec clusters_config() :: keyword
+  defp clusters_config(), do: fetch_envoy_config!(:clusters)
+
+  @spec fetch_clusters_config!(atom) :: any
+  def fetch_clusters_config!(key), do: clusters_config() |> Keyword.fetch!(key)
+
+  @spec endpoints_config() :: keyword
+  defp endpoints_config, do: fetch_clusters_config!(:endpoints)
+
+  @spec fetch_endpoints_config!(atom) :: any
+  def fetch_endpoints_config!(key), do: endpoints_config() |> Keyword.fetch!(key)
+
+  @spec listener_config(atom) :: keyword
+  defp listener_config(listener), do: fetch_envoy_config!(:listeners) |> Keyword.fetch!(listener)
+
+  @spec fetch_listener_config!(atom, atom) :: any
+  def fetch_listener_config!(listener, key),
+    do: listener |> listener_config() |> Keyword.fetch!(key)
+
+  @spec get_listener_config(atom, atom, any) :: any
+  def get_listener_config(listener, key, default),
+    do: listener |> listener_config() |> Keyword.get(key, default)
+
+  @spec marathon_acme_config() :: keyword
+  defp marathon_acme_config, do: Application.fetch_env!(:relay, :marathon_acme)
+
+  def fetch_marathon_acme_config!(key), do: marathon_acme_config() |> Keyword.fetch!(key)
+end

--- a/lib/relay/resources/eds.ex
+++ b/lib/relay/resources/eds.ex
@@ -2,9 +2,8 @@ defmodule Relay.Resources.EDS do
   @moduledoc """
   Builds Envoy ClusterLoadAssignment values from cluster resources.
   """
-  alias Relay.Resources.AppEndpoint
+  alias Relay.Resources.{AppEndpoint, Config}
   import Relay.Resources.Common, only: [socket_address: 2]
-  import Relay.Resources.Config, only: [fetch_endpoints_config!: 1]
 
   alias Envoy.Api.V2.ClusterLoadAssignment
   alias Envoy.Api.V2.Core.Locality
@@ -46,7 +45,7 @@ defmodule Relay.Resources.EDS do
   @spec default_locality() :: Locality.t()
   def default_locality do
     :locality
-    |> fetch_endpoints_config!()
+    |> Config.fetch_endpoints!()
     |> Keyword.take([:region, :zone, :sub_zone])
     |> Locality.new()
   end

--- a/lib/relay/resources/eds.ex
+++ b/lib/relay/resources/eds.ex
@@ -2,7 +2,8 @@ defmodule Relay.Resources.EDS do
   @moduledoc """
   Builds Envoy ClusterLoadAssignment values from cluster resources.
   """
-  alias Relay.Resources.{AppEndpoint, Common, CDS}
+  alias Relay.Resources.{AppEndpoint, Common}
+  import Relay.Resources.Config, only: [fetch_endpoints_config!: 1]
 
   alias Envoy.Api.V2.ClusterLoadAssignment
   alias Envoy.Api.V2.Core.Locality
@@ -44,11 +45,6 @@ defmodule Relay.Resources.EDS do
       ] ++ options
     )
   end
-
-  @spec endpoints_config() :: keyword
-  defp endpoints_config, do: CDS.clusters_config() |> Keyword.fetch!(:endpoints)
-
-  defp fetch_endpoints_config!(key), do: endpoints_config() |> Keyword.fetch!(key)
 
   @spec default_locality() :: Locality.t()
   def default_locality do

--- a/lib/relay/resources/eds.ex
+++ b/lib/relay/resources/eds.ex
@@ -2,7 +2,8 @@ defmodule Relay.Resources.EDS do
   @moduledoc """
   Builds Envoy ClusterLoadAssignment values from cluster resources.
   """
-  alias Relay.Resources.{AppEndpoint, Common}
+  alias Relay.Resources.AppEndpoint
+  import Relay.Resources.Common, only: [socket_address: 2]
   import Relay.Resources.Config, only: [fetch_endpoints_config!: 1]
 
   alias Envoy.Api.V2.ClusterLoadAssignment
@@ -39,11 +40,7 @@ defmodule Relay.Resources.EDS do
 
   @spec lb_endpoint({String.t(), :inet.port_number()}, keyword) :: LbEndpoint.t()
   defp lb_endpoint({address, port}, options) do
-    LbEndpoint.new(
-      [
-        endpoint: Endpoint.new(address: Common.socket_address(address, port))
-      ] ++ options
-    )
+    LbEndpoint.new([endpoint: Endpoint.new(address: socket_address(address, port))] ++ options)
   end
 
   @spec default_locality() :: Locality.t()

--- a/lib/relay/resources/lds.ex
+++ b/lib/relay/resources/lds.ex
@@ -2,12 +2,11 @@ defmodule Relay.Resources.LDS do
   @moduledoc """
   Builds Envoy Listener values from cluster resources.
   """
-  alias Relay.{ProtobufUtil, Resources.CertInfo}
+  alias Relay.ProtobufUtil
+  alias Relay.Resources.{CertInfo, Config}
 
   import Relay.Resources.Common,
     only: [api_config_source: 0, socket_address: 2, truncate_obj_name: 1]
-
-  import Relay.Resources.Config, only: [fetch_listener_config!: 2, get_listener_config: 3]
 
   alias Envoy.Api.V2.Core.DataSource
   alias Envoy.Api.V2.Listener
@@ -90,12 +89,12 @@ defmodule Relay.Resources.LDS do
   @spec get_route_config_name(atom) :: String.t()
   def get_route_config_name(listener) do
     listener
-    |> get_listener_config(:route_config_name, Atom.to_string(listener))
+    |> Config.get_listener(:route_config_name, Atom.to_string(listener))
     |> truncate_obj_name()
   end
 
   defp listener_address(listener) do
-    listen = fetch_listener_config!(listener, :listen)
+    listen = Config.fetch_listener!(listener, :listen)
     socket_address(Keyword.fetch!(listen, :address), Keyword.fetch!(listen, :port))
   end
 
@@ -109,7 +108,7 @@ defmodule Relay.Resources.LDS do
 
   @spec http_connection_manager(atom, keyword) :: HttpConnectionManager.t()
   defp http_connection_manager(listener, options) do
-    config = fetch_listener_config!(listener, :http_connection_manager)
+    config = Config.fetch_listener!(listener, :http_connection_manager)
     stat_prefix = Keyword.get(config, :stat_prefix, Atom.to_string(listener))
     access_log = Keyword.get(config, :access_log) |> access_logs_from_config()
 
@@ -140,7 +139,7 @@ defmodule Relay.Resources.LDS do
 
   @spec router(atom, keyword) :: Router.t()
   defp router(listener, options) do
-    config = fetch_listener_config!(listener, :router)
+    config = Config.fetch_listener!(listener, :router)
     upstream_log = Keyword.get(config, :upstream_log) |> access_logs_from_config()
 
     Router.new([upstream_log: upstream_log] ++ options)

--- a/lib/relay/resources/lds.ex
+++ b/lib/relay/resources/lds.ex
@@ -86,13 +86,6 @@ defmodule Relay.Resources.LDS do
     )
   end
 
-  @spec get_route_config_name(atom) :: String.t()
-  def get_route_config_name(listener) do
-    listener
-    |> Config.get_listener(:route_config_name, Atom.to_string(listener))
-    |> truncate_obj_name()
-  end
-
   defp listener_address(listener) do
     listen = Config.fetch_listener!(listener, :listen)
     socket_address(Keyword.fetch!(listen, :address), Keyword.fetch!(listen, :port))
@@ -112,7 +105,8 @@ defmodule Relay.Resources.LDS do
     stat_prefix = Keyword.get(config, :stat_prefix, Atom.to_string(listener))
     access_log = Keyword.get(config, :access_log) |> access_logs_from_config()
 
-    route_config_name = get_route_config_name(listener)
+    # TODO: Validate that the configured name is less than max_obj_name_length
+    route_config_name = Config.get_listener_route_config_name(listener)
 
     {options, router_opts} = Keyword.pop(options, :router_opts, [])
 

--- a/lib/relay/resources/lds.ex
+++ b/lib/relay/resources/lds.ex
@@ -5,6 +5,8 @@ defmodule Relay.Resources.LDS do
   alias Relay.{ProtobufUtil, Resources.CertInfo}
   import Relay.Resources.Common
 
+  import Relay.Resources.Config, only: [fetch_listener_config!: 2, get_listener_config: 3]
+
   alias Envoy.Api.V2.Core.DataSource
   alias Envoy.Api.V2.Listener
   alias Listener.{Filter, FilterChain, FilterChainMatch}
@@ -83,17 +85,10 @@ defmodule Relay.Resources.LDS do
     )
   end
 
-  @spec listener_config(atom) :: keyword
-  defp listener_config(listener), do: fetch_envoy_config!(:listeners) |> Keyword.fetch!(listener)
-
-  defp fetch_listener_config!(listener, key),
-    do: listener |> listener_config() |> Keyword.fetch!(key)
-
   @spec get_route_config_name(atom) :: String.t()
   def get_route_config_name(listener) do
     listener
-    |> listener_config()
-    |> Keyword.get(:route_config_name, Atom.to_string(listener))
+    |> get_listener_config(:route_config_name, Atom.to_string(listener))
     |> truncate_obj_name()
   end
 

--- a/lib/relay/resources/lds.ex
+++ b/lib/relay/resources/lds.ex
@@ -3,7 +3,9 @@ defmodule Relay.Resources.LDS do
   Builds Envoy Listener values from cluster resources.
   """
   alias Relay.{ProtobufUtil, Resources.CertInfo}
-  import Relay.Resources.Common
+
+  import Relay.Resources.Common,
+    only: [api_config_source: 0, socket_address: 2, truncate_obj_name: 1]
 
   import Relay.Resources.Config, only: [fetch_listener_config!: 2, get_listener_config: 3]
 

--- a/lib/relay/resources/rds.ex
+++ b/lib/relay/resources/rds.ex
@@ -2,9 +2,7 @@ defmodule Relay.Resources.RDS do
   @moduledoc """
   Builds Envoy RouteConfiguration values from cluster resources.
   """
-  alias Relay.Resources.{AppEndpoint, LDS}
-
-  import Relay.Resources.Config, only: [fetch_marathon_acme_config!: 1]
+  alias Relay.Resources.{AppEndpoint, Config, LDS}
 
   alias Envoy.Api.V2.RouteConfiguration
   alias Envoy.Api.V2.Route.{RedirectAction, Route, RouteAction, RouteMatch, VirtualHost}
@@ -95,8 +93,8 @@ defmodule Relay.Resources.RDS do
 
   @spec marathon_acme_route() :: Route.t()
   defp marathon_acme_route do
-    app_id = fetch_marathon_acme_config!(:app_id)
-    port_index = fetch_marathon_acme_config!(:port_index)
+    app_id = Config.fetch_marathon_acme!(:app_id)
+    port_index = Config.fetch_marathon_acme!(:port_index)
     # TODO: Does the cluster name here need to be truncated?
     cluster = "#{app_id}_#{port_index}"
 

--- a/lib/relay/resources/rds.ex
+++ b/lib/relay/resources/rds.ex
@@ -26,11 +26,13 @@ defmodule Relay.Resources.RDS do
   @spec virtual_host(atom, AppEndpoint.t()) :: VirtualHost.t()
   defp virtual_host(listener, app_endpoint) do
     VirtualHost.new(
-      # TODO: Do VirtualHost names need to be truncated?
-      name: "#{listener}_#{app_endpoint.name}",
-      # TODO: Validate domains
-      domains: app_endpoint.domains,
-      routes: app_endpoint_routes(listener, app_endpoint)
+      [
+        # TODO: Do VirtualHost names need to be truncated?
+        name: "#{listener}_#{app_endpoint.name}",
+        # TODO: Validate domains
+        domains: app_endpoint.domains,
+        routes: app_endpoint_routes(listener, app_endpoint)
+      ] ++ app_endpoint.vhost_opts
     )
   end
 

--- a/lib/relay/resources/rds.ex
+++ b/lib/relay/resources/rds.ex
@@ -4,6 +4,8 @@ defmodule Relay.Resources.RDS do
   """
   alias Relay.Resources.{AppEndpoint, LDS}
 
+  import Relay.Resources.Config, only: [fetch_marathon_acme_config!: 1]
+
   alias Envoy.Api.V2.RouteConfiguration
   alias Envoy.Api.V2.Route.{RedirectAction, Route, RouteAction, RouteMatch, VirtualHost}
 
@@ -93,9 +95,10 @@ defmodule Relay.Resources.RDS do
 
   @spec marathon_acme_route() :: Route.t()
   defp marathon_acme_route do
-    config = Application.fetch_env!(:relay, :marathon_acme)
+    app_id = fetch_marathon_acme_config!(:app_id)
+    port_index = fetch_marathon_acme_config!(:port_index)
     # TODO: Does the cluster name here need to be truncated?
-    cluster = "#{Keyword.fetch!(config, :app_id)}_#{Keyword.fetch!(config, :port_index)}"
+    cluster = "#{app_id}_#{port_index}"
 
     Route.new(
       action: {:route, RouteAction.new(cluster_specifier: {:cluster, cluster})},

--- a/lib/relay/resources/rds.ex
+++ b/lib/relay/resources/rds.ex
@@ -2,7 +2,7 @@ defmodule Relay.Resources.RDS do
   @moduledoc """
   Builds Envoy RouteConfiguration values from cluster resources.
   """
-  alias Relay.Resources.AppEndpoint
+  alias Relay.Resources.{AppEndpoint, LDS}
 
   alias Envoy.Api.V2.RouteConfiguration
   alias Envoy.Api.V2.Route.{RedirectAction, Route, RouteAction, RouteMatch, VirtualHost}
@@ -17,10 +17,10 @@ defmodule Relay.Resources.RDS do
 
   @spec route_configuration(atom, [AppEndpoint.t()]) :: RouteConfiguration.t()
   defp route_configuration(listener, app_endpoints) do
-    # TODO: Use route config name from config
-    name = Atom.to_string(listener)
+    route_config_name = LDS.get_route_config_name(listener)
+
     vhosts = app_endpoints |> Enum.map(&virtual_host(listener, &1))
-    RouteConfiguration.new(name: name, virtual_hosts: vhosts)
+    RouteConfiguration.new(name: route_config_name, virtual_hosts: vhosts)
   end
 
   @spec virtual_host(atom, AppEndpoint.t()) :: VirtualHost.t()

--- a/lib/relay/resources/rds.ex
+++ b/lib/relay/resources/rds.ex
@@ -2,7 +2,7 @@ defmodule Relay.Resources.RDS do
   @moduledoc """
   Builds Envoy RouteConfiguration values from cluster resources.
   """
-  alias Relay.Resources.{AppEndpoint, Config, LDS}
+  alias Relay.Resources.{AppEndpoint, Config}
 
   alias Envoy.Api.V2.RouteConfiguration
   alias Envoy.Api.V2.Route.{RedirectAction, Route, RouteAction, RouteMatch, VirtualHost}
@@ -17,7 +17,8 @@ defmodule Relay.Resources.RDS do
 
   @spec route_configuration(atom, [AppEndpoint.t()]) :: RouteConfiguration.t()
   defp route_configuration(listener, app_endpoints) do
-    route_config_name = LDS.get_route_config_name(listener)
+    # TODO: Validate that the configured name is less than max_obj_name_length
+    route_config_name = Config.get_listener_route_config_name(listener)
 
     vhosts = app_endpoints |> Enum.map(&virtual_host(listener, &1))
     RouteConfiguration.new(name: route_config_name, virtual_hosts: vhosts)

--- a/test/relay/resources/common_test.exs
+++ b/test/relay/resources/common_test.exs
@@ -3,6 +3,8 @@ defmodule Relay.Resources.CommonTest do
 
   alias Relay.Resources.Common
 
+  alias Google.Protobuf.Duration
+
   describe "truncate_obj_name/1" do
     test "long names truncated from beginning" do
       TestHelpers.put_env(:relay, :envoy, max_obj_name_length: 10)
@@ -14,6 +16,25 @@ defmodule Relay.Resources.CommonTest do
       TestHelpers.put_env(:relay, :envoy, max_obj_name_length: 10)
 
       assert Common.truncate_obj_name("hello") == "hello"
+    end
+  end
+
+  describe "duration/1" do
+    test "positive duration" do
+      assert Common.duration(500) == %Duration{seconds: 0, nanos: 500_000_000}
+      assert Common.duration(1_000) == %Duration{seconds: 1, nanos: 0}
+      assert Common.duration(1_500) == %Duration{seconds: 1, nanos: 500_000_000}
+    end
+
+    test "negative duration" do
+      assert Common.duration(-500) == %Duration{seconds: 0, nanos: -500_000_000}
+      # "a non-zero value for the nanos field must be of the same sign as the seconds field"
+      assert Common.duration(-1_000) == %Duration{seconds: -1, nanos: 0}
+      assert Common.duration(-1_500) == %Duration{seconds: -1, nanos: -500_000_000}
+    end
+
+    test "zero duration" do
+      assert Common.duration(0) == %Duration{seconds: 0, nanos: 0}
     end
   end
 end


### PR DESCRIPTION
* RDS: Use `route_config_name` config option already used in LDS
* RDS: Add opts to `AppEndpoint`
* CDS: Make the default connect timeout configurable
* EDS: Make the default locality configurable

Fixes #53