### PR TITLE
Align Alpine versions across build and runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN mix release --env=prod
 
 # We don't actually need Erlang/Elixir installed, because it's all included in
 # the release package. Thus, we start from the base alpine image.
-FROM alpine:3.8
+FROM alpine:3.9
 
 # We need bash for the generated scripts, tini for signal propagation, and
 # openssl for crypto.


### PR DESCRIPTION
Currently the container fails to start due to a mismatching libcrypto version. This appears to be caused by elixir-1.6 depending on erlang-20 which depends on alpine-3.9. Switching to 3.9 at runtime fixes this.